### PR TITLE
Items List Feature

### DIFF
--- a/assets/items.json
+++ b/assets/items.json
@@ -3,13 +3,13 @@
     "name": "Ability Capsule",
     "imageurl": "https://img.pokemondb.net/sprites/items/ability-capsule.png",
     "category": "Hold items",
-    "effect": "A capsule that allows a Pok\u00e9mon with two Abilities to switch between these Abilities when it is used."
+    "effect": "A capsule that allows a Pokemon with two Abilities to switch between these Abilities when it is used."
   },
   {
     "name": "Ability Urge",
     "imageurl": "https://img.pokemondb.net/sprites/items/ability-urge.png",
     "category": "Battle items",
-    "effect": "When used, it activates the Ability of an ally Pok\u00e9mon."
+    "effect": "When used, it activates the Ability of an ally Pokemon."
   },
   {
     "name": "Abomasite",
@@ -33,7 +33,7 @@
     "name": "Adamant Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Adamant nature."
+    "effect": "Changes the Pokemon's stats to match the Adamant nature."
   },
   {
     "name": "Adamant Orb",
@@ -45,7 +45,7 @@
     "name": "Adrenaline Orb",
     "imageurl": "https://img.pokemondb.net/sprites/items/adrenaline-orb.png",
     "category": "Hold items",
-    "effect": "Using it makes wild Pok\u00e9mon more likely to call for help. If held by a Pok\u00e9mon, it boosts Speed when intimidated. It can be used only once."
+    "effect": "Using it makes wild Pokemon more likely to call for help. If held by a Pokemon, it boosts Speed when intimidated. It can be used only once."
   },
   {
     "name": "Aerodactylite",
@@ -69,7 +69,7 @@
     "name": "Air Balloon",
     "imageurl": "https://img.pokemondb.net/sprites/items/air-balloon.png",
     "category": "Hold items",
-    "effect": "When held by a Pok\u00e9mon, the Pok\u00e9mon will float into the air. When the holder is attacked, this item will burst."
+    "effect": "When held by a Pokemon, the Pokemon will float into the air. When the holder is attacked, this item will burst."
   },
   {
     "name": "Alakazite",
@@ -105,7 +105,7 @@
     "name": "Antidote",
     "imageurl": "https://img.pokemondb.net/sprites/items/antidote.png",
     "category": "Medicine",
-    "effect": "A spray-type medicine. It lifts the effect of poison from one Pok\u00e9mon."
+    "effect": "A spray-type medicine. It lifts the effect of poison from one Pokemon."
   },
   {
     "name": "Apicot Berry",
@@ -117,13 +117,13 @@
     "name": "Armor Fossil",
     "imageurl": "https://img.pokemondb.net/sprites/items/armor-fossil.png",
     "category": "General items",
-    "effect": "A fossil from a prehistoric Pok\u00e9mon that lived on the land. It appears to be part of a collar."
+    "effect": "A fossil from a prehistoric Pokemon that lived on the land. It appears to be part of a collar."
   },
   {
     "name": "Aspear Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/aspear-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, it defrosts it."
+    "effect": "If held by a Pokemon, it defrosts it."
   },
   {
     "name": "Assault Vest",
@@ -141,13 +141,13 @@
     "name": "Awakening",
     "imageurl": "https://img.pokemondb.net/sprites/items/awakening.png",
     "category": "Medicine",
-    "effect": "A spray-type medicine. It awakens a Pok\u00e9mon from the clutches of sleep."
+    "effect": "A spray-type medicine. It awakens a Pokemon from the clutches of sleep."
   },
   {
     "name": "Babiri Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/babiri-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Steel-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Steel-type attack against the holding Pokemon."
   },
   {
     "name": "Balm Mushroom",
@@ -171,7 +171,7 @@
     "name": "Beast Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/beast-ball.png",
     "category": "Pokeballs",
-    "effect": "A special Pok\u00e9 Ball designed to catch Ultra Beasts. It has a low success rate for catching others."
+    "effect": "A special Poke Ball designed to catch Ultra Beasts. It has a low success rate for catching others."
   },
   {
     "name": "Beedrillite",
@@ -189,7 +189,7 @@
     "name": "Berry Juice",
     "imageurl": "https://img.pokemondb.net/sprites/items/berry-juice.png",
     "category": "Medicine",
-    "effect": "A 100% pure juice made of Berries. It restores the HP of one Pok\u00e9mon by just 20 points."
+    "effect": "A 100% pure juice made of Berries. It restores the HP of one Pokemon by just 20 points."
   },
   {
     "name": "Big Malasada",
@@ -255,7 +255,7 @@
     "name": "Black Sludge",
     "imageurl": "https://img.pokemondb.net/sprites/items/black-sludge.png",
     "category": "Hold items",
-    "effect": "A held item that gradually restores the HP of Poison-type Pok\u00e9mon. It inflicts damage on all other types."
+    "effect": "A held item that gradually restores the HP of Poison-type Pokemon. It inflicts damage on all other types."
   },
   {
     "name": "Blastoisinite",
@@ -315,7 +315,7 @@
     "name": "Bold Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Bold nature."
+    "effect": "Changes the Pokemon's stats to match the Bold nature."
   },
   {
     "name": "Bottle Cap",
@@ -327,7 +327,7 @@
     "name": "Brave Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Brave nature."
+    "effect": "Changes the Pokemon's stats to match the Brave nature."
   },
   {
     "name": "Bright Powder",
@@ -363,7 +363,7 @@
     "name": "Burn Heal",
     "imageurl": "https://img.pokemondb.net/sprites/items/burn-heal.png",
     "category": "Medicine",
-    "effect": "A spray-type medicine. It heals a single Pok\u00e9mon that is suffering from a burn."
+    "effect": "A spray-type medicine. It heals a single Pokemon that is suffering from a burn."
   },
   {
     "name": "Calcium",
@@ -375,7 +375,7 @@
     "name": "Calm Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Calm nature."
+    "effect": "Changes the Pokemon's stats to match the Calm nature."
   },
   {
     "name": "Cameruptite",
@@ -393,7 +393,7 @@
     "name": "Careful Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Careful nature."
+    "effect": "Changes the Pokemon's stats to match the Careful nature."
   },
   {
     "name": "Casteliacone",
@@ -435,31 +435,31 @@
     "name": "Charti Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/charti-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Rock-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Rock-type attack against the holding Pokemon."
   },
   {
     "name": "Cheri Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/cheri-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, it recovers from paralysis."
+    "effect": "If held by a Pokemon, it recovers from paralysis."
   },
   {
     "name": "Cherish Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/cherish-ball.png",
     "category": "Pokeballs",
-    "effect": "A quite rare Pok\u00e9 Ball that has been specially crafted to commemorate an occasion of some sort."
+    "effect": "A quite rare Poke Ball that has been specially crafted to commemorate an occasion of some sort."
   },
   {
     "name": "Chesto Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/chesto-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, it recovers from sleep."
+    "effect": "If held by a Pokemon, it recovers from sleep."
   },
   {
     "name": "Chilan Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/chilan-berry.png",
     "category": "Berries",
-    "effect": "Weakens a Normal-type attack against the Pok\u00e9mon holding this berry."
+    "effect": "Weakens a Normal-type attack against the Pokemon holding this berry."
   },
   {
     "name": "Chill Drive",
@@ -489,19 +489,19 @@
     "name": "Chople Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/chople-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Fighting-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Fighting-type attack against the holding Pokemon."
   },
   {
     "name": "Claw Fossil",
     "imageurl": "https://img.pokemondb.net/sprites/items/claw-fossil.png",
     "category": "General items",
-    "effect": "A fossil of an ancient Pok\u00e9mon that lived in the sea. It appears to be part of a claw."
+    "effect": "A fossil of an ancient Pokemon that lived in the sea. It appears to be part of a claw."
   },
   {
     "name": "Cleanse Tag",
     "imageurl": "https://img.pokemondb.net/sprites/items/cleanse-tag.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. It helps keep wild Pok\u00e9mon away if the holder is the first one in the party."
+    "effect": "An item to be held by a Pokemon. It helps keep wild Pokemon away if the holder is the first one in the party."
   },
   {
     "name": "Clever Wing",
@@ -519,19 +519,19 @@
     "name": "Coba Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/coba-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Flying-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Flying-type attack against the holding Pokemon."
   },
   {
     "name": "Colbur Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/colbur-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Dark-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Dark-type attack against the holding Pokemon."
   },
   {
     "name": "Colress Machine",
     "imageurl": "https://img.pokemondb.net/sprites/items/colress-machine.png",
     "category": "Hold items",
-    "effect": "A special device that wrings out the potential of Pok\u00e9mon. It is an imperfect prototype."
+    "effect": "A special device that wrings out the potential of Pokemon. It is an imperfect prototype."
   },
   {
     "name": "Comet Shard",
@@ -549,25 +549,25 @@
     "name": "Courage Candy",
     "imageurl": "https://img.pokemondb.net/sprites/items/courage-candy.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Special Defense stat by 1."
+    "effect": "Increases a Pokemon's Special Defense stat by 1."
   },
   {
     "name": "Courage Candy L",
     "imageurl": "https://img.pokemondb.net/sprites/items/courage-candy-l.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Special Defense stat."
+    "effect": "Increases a Pokemon's Special Defense stat."
   },
   {
     "name": "Courage Candy XL",
     "imageurl": "https://img.pokemondb.net/sprites/items/courage-candy-xl.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Special Defense stat."
+    "effect": "Increases a Pokemon's Special Defense stat."
   },
   {
     "name": "Cover Fossil",
     "imageurl": "https://img.pokemondb.net/sprites/items/cover-fossil.png",
     "category": "General items",
-    "effect": "A fossil of an ancient Pok\u00e9mon that lived in the sea in ancient times. It appears to be part of its back."
+    "effect": "A fossil of an ancient Pokemon that lived in the sea in ancient times. It appears to be part of its back."
   },
   {
     "name": "Custap Berry",
@@ -585,7 +585,7 @@
     "name": "Damp Rock",
     "imageurl": "https://img.pokemondb.net/sprites/items/damp-rock.png",
     "category": "Hold items",
-    "effect": "A Pok\u00e9mon held item that extends the duration of the move Rain Dance used by the holder."
+    "effect": "A Pokemon held item that extends the duration of the move Rain Dance used by the holder."
   },
   {
     "name": "Dark Gem",
@@ -609,7 +609,7 @@
     "name": "Dawn Stone",
     "imageurl": "https://img.pokemondb.net/sprites/items/dawn-stone.png",
     "category": "General items",
-    "effect": "Evolves certain species of Pok\u00e9mon."
+    "effect": "Evolves certain species of Pokemon."
   },
   {
     "name": "Decidium Z",
@@ -633,7 +633,7 @@
     "name": "Destiny Knot",
     "imageurl": "https://img.pokemondb.net/sprites/items/destiny-knot.png",
     "category": "Hold items",
-    "effect": "A long, thin, bright-red string to be held by a Pok\u00e9mon. If the holder becomes infatuated, the foe does too."
+    "effect": "A long, thin, bright-red string to be held by a Pokemon. If the holder becomes infatuated, the foe does too."
   },
   {
     "name": "Diancite",
@@ -645,19 +645,19 @@
     "name": "Dire Hit",
     "imageurl": "https://img.pokemondb.net/sprites/items/dire-hit.png",
     "category": "Battle items",
-    "effect": "Raises critical-hit ratio of a Pok\u00e9mon in battle."
+    "effect": "Raises critical-hit ratio of a Pokemon in battle."
   },
   {
     "name": "Dire Hit 2",
     "imageurl": "https://img.pokemondb.net/sprites/items/dire-hit-2.png",
     "category": "Battle items",
-    "effect": "Raises a Pok\u00e9mon's critical-hit ratio in battle."
+    "effect": "Raises a Pokemon's critical-hit ratio in battle."
   },
   {
     "name": "Dire Hit 3",
     "imageurl": "https://img.pokemondb.net/sprites/items/dire-hit-3.png",
     "category": "Battle items",
-    "effect": "Greatly raises a Pok\u00e9mon's critical-hit ratio in battle."
+    "effect": "Greatly raises a Pokemon's critical-hit ratio in battle."
   },
   {
     "name": "Discount Coupon",
@@ -669,19 +669,19 @@
     "name": "Dive Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/dive-ball.png",
     "category": "Pokeballs",
-    "effect": "A somewhat different Pok\u00e9 Ball that works especially well on Pok\u00e9mon that live underwater."
+    "effect": "A somewhat different Poke Ball that works especially well on Pokemon that live underwater."
   },
   {
     "name": "DNA Splicers",
     "imageurl": "https://img.pokemondb.net/sprites/items/dna-splicers.png",
     "category": "General items",
-    "effect": "A splicer that fuses Kyurem and a certain Pok\u00e9mon. They are said to have been one in the beginning."
+    "effect": "A splicer that fuses Kyurem and a certain Pokemon. They are said to have been one in the beginning."
   },
   {
     "name": "Dome Fossil",
     "imageurl": "https://img.pokemondb.net/sprites/items/dome-fossil.png",
     "category": "General items",
-    "effect": "A fossil of an ancient Pok\u00e9mon that lived in the sea. It appears to be part of a shell."
+    "effect": "A fossil of an ancient Pokemon that lived in the sea. It appears to be part of a shell."
   },
   {
     "name": "Douse Drive",
@@ -735,7 +735,7 @@
     "name": "Dream Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/dream-ball.png",
     "category": "Pokeballs",
-    "effect": "A special Pok\u00e9 Ball that appears out of nowhere in a bag at the Entree Forest. It can catch any Pok\u00e9mon."
+    "effect": "A special Poke Ball that appears out of nowhere in a bag at the Entree Forest. It can catch any Pokemon."
   },
   {
     "name": "Dropped Item",
@@ -759,13 +759,13 @@
     "name": "Dusk Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/dusk-ball.png",
     "category": "Pokeballs",
-    "effect": "A somewhat different Pok\u00e9 Ball that makes it easier to catch wild Pok\u00e9mon at night or in dark places like caves."
+    "effect": "A somewhat different Poke Ball that makes it easier to catch wild Pokemon at night or in dark places like caves."
   },
   {
     "name": "Dusk Stone",
     "imageurl": "https://img.pokemondb.net/sprites/items/dusk-stone.png",
     "category": "General items",
-    "effect": "Evolves certain species of Pok\u00e9mon."
+    "effect": "Evolves certain species of Pokemon."
   },
   {
     "name": "Dynamax Candy",
@@ -789,13 +789,13 @@
     "name": "Eject Button",
     "imageurl": "https://img.pokemondb.net/sprites/items/eject-button.png",
     "category": "Hold items",
-    "effect": "If the holder is hit by an attack, it will switch with another Pok\u00e9mon in your party."
+    "effect": "If the holder is hit by an attack, it will switch with another Pokemon in your party."
   },
   {
     "name": "Eject Pack",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Hold items",
-    "effect": "The Pok\u00e9mon switches out if its stats are lowered."
+    "effect": "The Pokemon switches out if its stats are lowered."
   },
   {
     "name": "Electirizer",
@@ -819,7 +819,7 @@
     "name": "Electric Seed",
     "imageurl": "https://img.pokemondb.net/sprites/items/electric-seed.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. It boosts Defense on Electric Terrain. It can only be used once."
+    "effect": "An item to be held by a Pokemon. It boosts Defense on Electric Terrain. It can only be used once."
   },
   {
     "name": "Electrium Z",
@@ -837,7 +837,7 @@
     "name": "Elixir",
     "imageurl": "https://img.pokemondb.net/sprites/items/elixir.png",
     "category": "Medicine",
-    "effect": "It restores the PP of all the moves learned by the targeted Pok\u00e9mon by 10 points each."
+    "effect": "It restores the PP of all the moves learned by the targeted Pokemon by 10 points each."
   },
   {
     "name": "Energy Powder",
@@ -855,7 +855,7 @@
     "name": "Enigma Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/enigma-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, it restores its HP if it is hit by any supereffective attack."
+    "effect": "If held by a Pokemon, it restores its HP if it is hit by any supereffective attack."
   },
   {
     "name": "Escape Rope",
@@ -867,19 +867,19 @@
     "name": "Ether",
     "imageurl": "https://img.pokemondb.net/sprites/items/ether.png",
     "category": "Medicine",
-    "effect": "It restores the PP of a Pok\u00e9mon's selected move by a maximum of 10 points."
+    "effect": "It restores the PP of a Pokemon's selected move by a maximum of 10 points."
   },
   {
     "name": "Everstone",
     "imageurl": "https://img.pokemondb.net/sprites/items/everstone.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. The Pok\u00e9mon holding this peculiar stone is prevented from evolving."
+    "effect": "An item to be held by a Pokemon. The Pokemon holding this peculiar stone is prevented from evolving."
   },
   {
     "name": "Eviolite",
     "imageurl": "https://img.pokemondb.net/sprites/items/eviolite.png",
     "category": "Hold items",
-    "effect": "A mysterious evolutionary lump. When held, it raises the Defense and Sp. Def of a Pok\u00e9mon that can still evolve."
+    "effect": "A mysterious evolutionary lump. When held, it raises the Defense and Sp. Def of a Pokemon that can still evolve."
   },
   {
     "name": "Exp. Candy L",
@@ -903,7 +903,7 @@
     "name": "Exp. Candy XL",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Medicine",
-    "effect": "Increases the Pok\u00e9mon's Exp points by 30,000."
+    "effect": "Increases the Pokemon's Exp points by 30,000."
   },
   {
     "name": "Exp. Candy XS",
@@ -915,7 +915,7 @@
     "name": "Exp. Share",
     "imageurl": "https://img.pokemondb.net/sprites/items/exp-share.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. The holder gets a share of a battle's Exp. Points without battling."
+    "effect": "An item to be held by a Pokemon. The holder gets a share of a battle's Exp. Points without battling."
   },
   {
     "name": "Expert Belt",
@@ -945,7 +945,7 @@
     "name": "Fast Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/fast-ball.png",
     "category": "Pokeballs",
-    "effect": "A Pok\u00e9 Ball that makes it easier to catch Pok\u00e9mon which are quick to run away."
+    "effect": "A Poke Ball that makes it easier to catch Pokemon which are quick to run away."
   },
   {
     "name": "Festival Ticket",
@@ -993,7 +993,7 @@
     "name": "Fire Stone",
     "imageurl": "https://img.pokemondb.net/sprites/items/fire-stone.png",
     "category": "General items",
-    "effect": "Evolves certain species of Pok\u00e9mon."
+    "effect": "Evolves certain species of Pokemon."
   },
   {
     "name": "Firium Z",
@@ -1011,7 +1011,7 @@
     "name": "Flame Orb",
     "imageurl": "https://img.pokemondb.net/sprites/items/flame-orb.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. It is a bizarre orb that inflicts a burn on the holder in battle."
+    "effect": "An item to be held by a Pokemon. It is a bizarre orb that inflicts a burn on the holder in battle."
   },
   {
     "name": "Flame Plate",
@@ -1023,7 +1023,7 @@
     "name": "Float Stone",
     "imageurl": "https://img.pokemondb.net/sprites/items/float-stone.png",
     "category": "Hold items",
-    "effect": "A very light stone. It reduces the weight of a Pok\u00e9mon when held."
+    "effect": "A very light stone. It reduces the weight of a Pokemon when held."
   },
   {
     "name": "Flower Sweet",
@@ -1035,7 +1035,7 @@
     "name": "Fluffy Tail",
     "imageurl": "https://img.pokemondb.net/sprites/items/fluffy-tail.png",
     "category": "General items",
-    "effect": "An item that attracts Pok\u00e9mon. Use it to flee from any battle with a wild Pok\u00e9mon."
+    "effect": "An item that attracts Pokemon. Use it to flee from any battle with a wild Pokemon."
   },
   {
     "name": "Flying Gem",
@@ -1059,13 +1059,13 @@
     "name": "Focus Band",
     "imageurl": "https://img.pokemondb.net/sprites/items/focus-band.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. The holder may endure a potential KO attack, leaving it with just 1 HP."
+    "effect": "An item to be held by a Pokemon. The holder may endure a potential KO attack, leaving it with just 1 HP."
   },
   {
     "name": "Focus Sash",
     "imageurl": "https://img.pokemondb.net/sprites/items/focus-sash.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. If it has full HP, the holder will endure one potential KO attack, leaving 1 HP."
+    "effect": "An item to be held by a Pokemon. If it has full HP, the holder will endure one potential KO attack, leaving 1 HP."
   },
   {
     "name": "Fresh Water",
@@ -1077,13 +1077,13 @@
     "name": "Friend Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/friend-ball.png",
     "category": "Pokeballs",
-    "effect": "A Pok\u00e9 Ball that makes caught Pok\u00e9mon more friendly."
+    "effect": "A Poke Ball that makes caught Pokemon more friendly."
   },
   {
     "name": "Full Heal",
     "imageurl": "https://img.pokemondb.net/sprites/items/full-heal.png",
     "category": "Medicine",
-    "effect": "A spray-type medicine. It heals all the status problems of a single Pok\u00e9mon."
+    "effect": "A spray-type medicine. It heals all the status problems of a single Pokemon."
   },
   {
     "name": "Full Incense",
@@ -1095,7 +1095,7 @@
     "name": "Full Restore",
     "imageurl": "https://img.pokemondb.net/sprites/items/full-restore.png",
     "category": "Medicine",
-    "effect": "A medicine that fully restores the HP and heals any status problems of a single Pok\u00e9mon."
+    "effect": "A medicine that fully restores the HP and heals any status problems of a single Pokemon."
   },
   {
     "name": "Galladite",
@@ -1137,7 +1137,7 @@
     "name": "Gentle Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Gentle nature."
+    "effect": "Changes the Pokemon's stats to match the Gentle nature."
   },
   {
     "name": "Ghost Gem",
@@ -1167,7 +1167,7 @@
     "name": "Gold Bottle Cap",
     "imageurl": "https://img.pokemondb.net/sprites/items/gold-bottle-cap.png",
     "category": "General items",
-    "effect": "Maximizes all of a Pok\u00e9mon's IV stats in Hyper Training."
+    "effect": "Maximizes all of a Pokemon's IV stats in Hyper Training."
   },
   {
     "name": "Gold Leaf",
@@ -1179,19 +1179,19 @@
     "name": "Golden Nanab Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/golden-nanab-berry.png",
     "category": "Berries",
-    "effect": "Drastically calms a Pok\u00e9mon in battle, in Let's Go Pikachu/Eevee."
+    "effect": "Drastically calms a Pokemon in battle, in Let's Go Pikachu/Eevee."
   },
   {
     "name": "Golden Pinap Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/golden-pinap-berry.png",
     "category": "Berries",
-    "effect": "Drastically increases chance of getting items when a Pok\u00e9mon is caught, in Pok\u00e9mon Let's Go."
+    "effect": "Drastically increases chance of getting items when a Pokemon is caught, in Pokemon Let's Go."
   },
   {
     "name": "Golden Razz Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/golden-razz-berry.png",
     "category": "Berries",
-    "effect": "Makes a Pok\u00e9mon easier to catch in Pok\u00e9mon Let's Go."
+    "effect": "Makes a Pokemon easier to catch in Pokemon Let's Go."
   },
   {
     "name": "Gooey Mulch",
@@ -1221,13 +1221,13 @@
     "name": "Grassy Seed",
     "imageurl": "https://img.pokemondb.net/sprites/items/grassy-seed.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. It boosts Defense on Grassy Terrain. It can only be used once."
+    "effect": "An item to be held by a Pokemon. It boosts Defense on Grassy Terrain. It can only be used once."
   },
   {
     "name": "Great Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/great-ball.png",
     "category": "Pokeballs",
-    "effect": "A good, high-performance Ball that provides a higher Pok\u00e9mon catch rate than a standard Pok\u00e9 Ball."
+    "effect": "A good, high-performance Ball that provides a higher Pokemon catch rate than a standard Poke Ball."
   },
   {
     "name": "Green Apricorn",
@@ -1257,7 +1257,7 @@
     "name": "Grip Claw",
     "imageurl": "https://img.pokemondb.net/sprites/items/grip-claw.png",
     "category": "Hold items",
-    "effect": "A Pok\u00e9mon held item that extends the duration of multiturn attacks like Bind and Wrap."
+    "effect": "A Pokemon held item that extends the duration of multiturn attacks like Bind and Wrap."
   },
   {
     "name": "Griseous Orb",
@@ -1293,7 +1293,7 @@
     "name": "Grubby Hanky",
     "imageurl": "https://img.pokemondb.net/sprites/items/grubby-hanky.png",
     "category": "Hold items",
-    "effect": "A handkerchief dropped by a regular at Caf\u00e9 Warehouse. It smells faintly like a Pok\u00e9mon."
+    "effect": "A handkerchief dropped by a regular at Caf\u00e9 Warehouse. It smells faintly like a Pokemon."
   },
   {
     "name": "Guard Spec.",
@@ -1311,7 +1311,7 @@
     "name": "Haban Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/haban-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Dragon-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Dragon-type attack against the holding Pokemon."
   },
   {
     "name": "Hard Stone",
@@ -1323,13 +1323,13 @@
     "name": "Hasty Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Hasty nature."
+    "effect": "Changes the Pokemon's stats to match the Hasty nature."
   },
   {
     "name": "Heal Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/heal-ball.png",
     "category": "Pokeballs",
-    "effect": "A remedial Pok\u00e9 Ball that restores the caught Pok\u00e9mon's HP and eliminates any status problem."
+    "effect": "A remedial Poke Ball that restores the caught Pokemon's HP and eliminates any status problem."
   },
   {
     "name": "Heal Powder",
@@ -1341,19 +1341,19 @@
     "name": "Health Candy",
     "imageurl": "https://img.pokemondb.net/sprites/items/health-candy.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's HP stat by 1."
+    "effect": "Increases a Pokemon's HP stat by 1."
   },
   {
     "name": "Health Candy L",
     "imageurl": "https://img.pokemondb.net/sprites/items/health-candy-l.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's HP stat."
+    "effect": "Increases a Pokemon's HP stat."
   },
   {
     "name": "Health Candy XL",
     "imageurl": "https://img.pokemondb.net/sprites/items/health-candy-xl.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's HP stat."
+    "effect": "Increases a Pokemon's HP stat."
   },
   {
     "name": "Health Wing",
@@ -1377,13 +1377,13 @@
     "name": "Heat Rock",
     "imageurl": "https://img.pokemondb.net/sprites/items/heat-rock.png",
     "category": "Hold items",
-    "effect": "A Pok\u00e9mon held item that extends the duration of the move Sunny Day used by the holder."
+    "effect": "A Pokemon held item that extends the duration of the move Sunny Day used by the holder."
   },
   {
     "name": "Heavy Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/heavy-ball.png",
     "category": "Pokeballs",
-    "effect": "A Pok\u00e9 Ball for catching very heavy Pok\u00e9mon."
+    "effect": "A Poke Ball for catching very heavy Pokemon."
   },
   {
     "name": "Heavy-Duty Boots",
@@ -1395,7 +1395,7 @@
     "name": "Helix Fossil",
     "imageurl": "https://img.pokemondb.net/sprites/items/helix-fossil.png",
     "category": "General items",
-    "effect": "A fossil of an ancient Pok\u00e9mon that lived in the sea. It appears to be part of a seashell."
+    "effect": "A fossil of an ancient Pokemon that lived in the sea. It appears to be part of a seashell."
   },
   {
     "name": "Heracronite",
@@ -1461,7 +1461,7 @@
     "name": "Honey",
     "imageurl": "https://img.pokemondb.net/sprites/items/honey.png",
     "category": "General items",
-    "effect": "A sweet honey with a lush aroma that attracts wild Pok\u00e9mon when it is used in grass, caves, or on special trees."
+    "effect": "A sweet honey with a lush aroma that attracts wild Pokemon when it is used in grass, caves, or on special trees."
   },
   {
     "name": "Honor Of Kalos",
@@ -1503,7 +1503,7 @@
     "name": "Ice Heal",
     "imageurl": "https://img.pokemondb.net/sprites/items/ice-heal.png",
     "category": "Medicine",
-    "effect": "A spray-type medicine. It defrosts a Pok\u00e9mon that has been frozen solid."
+    "effect": "A spray-type medicine. It defrosts a Pokemon that has been frozen solid."
   },
   {
     "name": "Ice Memory",
@@ -1515,7 +1515,7 @@
     "name": "Ice Stone",
     "imageurl": "https://img.pokemondb.net/sprites/items/ice-stone.png",
     "category": "General items",
-    "effect": "Evolves certain species of Pok\u00e9mon."
+    "effect": "Evolves certain species of Pokemon."
   },
   {
     "name": "Icicle Plate",
@@ -1533,13 +1533,13 @@
     "name": "Icy Rock",
     "imageurl": "https://img.pokemondb.net/sprites/items/icy-rock.png",
     "category": "Hold items",
-    "effect": "A Pok\u00e9mon held item that extends the duration of the move Hail used by the holder."
+    "effect": "A Pokemon held item that extends the duration of the move Hail used by the holder."
   },
   {
     "name": "Impish Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Impish nature."
+    "effect": "Changes the Pokemon's stats to match the Impish nature."
   },
   {
     "name": "Incinium Z",
@@ -1569,7 +1569,7 @@
     "name": "Iron Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/iron-ball.png",
     "category": "Hold items",
-    "effect": "A Pok\u00e9mon held item that cuts Speed. It makes Flying-type and levitating holders susceptible to Ground moves."
+    "effect": "A Pokemon held item that cuts Speed. It makes Flying-type and levitating holders susceptible to Ground moves."
   },
   {
     "name": "Iron Plate",
@@ -1581,25 +1581,25 @@
     "name": "Item Drop",
     "imageurl": "https://img.pokemondb.net/sprites/items/item-drop.png",
     "category": "Battle items",
-    "effect": "When used, it causes an ally Pok\u00e9mon to drop a held item."
+    "effect": "When used, it causes an ally Pokemon to drop a held item."
   },
   {
     "name": "Item Urge",
     "imageurl": "https://img.pokemondb.net/sprites/items/item-urge.png",
     "category": "Battle items",
-    "effect": "When used, it causes an ally Pok\u00e9mon to use its held item."
+    "effect": "When used, it causes an ally Pokemon to use its held item."
   },
   {
     "name": "Jaboca Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/jaboca-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon and a physical attack lands, the attacker also takes damage."
+    "effect": "If held by a Pokemon and a physical attack lands, the attacker also takes damage."
   },
   {
     "name": "Jolly Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Jolly nature."
+    "effect": "Changes the Pokemon's stats to match the Jolly nature."
   },
   {
     "name": "Kangaskhanite",
@@ -1611,19 +1611,19 @@
     "name": "Kasib Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/kasib-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Ghost-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Ghost-type attack against the holding Pokemon."
   },
   {
     "name": "Kebia Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/kebia-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Poison-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Poison-type attack against the holding Pokemon."
   },
   {
     "name": "Kee Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/kee-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, this Berry will increase the holder's Defense if it's hit with a physical move."
+    "effect": "If held by a Pokemon, this Berry will increase the holder's Defense if it's hit with a physical move."
   },
   {
     "name": "Kelpsy Berry",
@@ -1683,7 +1683,7 @@
     "name": "Lax Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Lax nature."
+    "effect": "Changes the Pokemon's stats to match the Lax nature."
   },
   {
     "name": "Leaf Letter",
@@ -1695,13 +1695,13 @@
     "name": "Leaf Stone",
     "imageurl": "https://img.pokemondb.net/sprites/items/leaf-stone.png",
     "category": "General items",
-    "effect": "Evolves certain species of Pok\u00e9mon."
+    "effect": "Evolves certain species of Pokemon."
   },
   {
     "name": "Leftovers",
     "imageurl": "https://img.pokemondb.net/sprites/items/leftovers.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. The holder's HP is gradually restored during battle."
+    "effect": "An item to be held by a Pokemon. The holder's HP is gradually restored during battle."
   },
   {
     "name": "Lemonade",
@@ -1713,13 +1713,13 @@
     "name": "Leppa Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/leppa-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, it restores a move's PP by 10."
+    "effect": "If held by a Pokemon, it restores a move's PP by 10."
   },
   {
     "name": "Level Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/level-ball.png",
     "category": "Pokeballs",
-    "effect": "A Pok\u00e9 Ball for catching Pok\u00e9mon that are a lower level than your own."
+    "effect": "A Poke Ball for catching Pokemon that are a lower level than your own."
   },
   {
     "name": "Liechi Berry",
@@ -1743,7 +1743,7 @@
     "name": "Light Clay",
     "imageurl": "https://img.pokemondb.net/sprites/items/light-clay.png",
     "category": "Hold items",
-    "effect": "A Pok\u00e9mon held item that extends the duration of barrier moves like Light Screen and Reflect used by the holder."
+    "effect": "A Pokemon held item that extends the duration of barrier moves like Light Screen and Reflect used by the holder."
   },
   {
     "name": "Lone Earring",
@@ -1755,7 +1755,7 @@
     "name": "Lonely Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Lonely nature."
+    "effect": "Changes the Pokemon's stats to match the Lonely nature."
   },
   {
     "name": "Looker Ticket",
@@ -1773,7 +1773,7 @@
     "name": "Love Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/love-ball.png",
     "category": "Pokeballs",
-    "effect": "Pok\u00e9 Ball for catching Pok\u00e9mon that are the opposite gender of your Pok\u00e9mon."
+    "effect": "Poke Ball for catching Pokemon that are the opposite gender of your Pokemon."
   },
   {
     "name": "Lucarionite",
@@ -1791,7 +1791,7 @@
     "name": "Lucky Egg",
     "imageurl": "https://img.pokemondb.net/sprites/items/lucky-egg.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. It is an egg filled with happiness that earns extra Exp. Points in battle."
+    "effect": "An item to be held by a Pokemon. It is an egg filled with happiness that earns extra Exp. Points in battle."
   },
   {
     "name": "Lucky Punch",
@@ -1803,7 +1803,7 @@
     "name": "Lum Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/lum-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, it recovers from any status problem."
+    "effect": "If held by a Pokemon, it recovers from any status problem."
   },
   {
     "name": "Luminous Moss",
@@ -1827,13 +1827,13 @@
     "name": "Lure",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "General items",
-    "effect": "Attracts Pok\u00e9mon in the wild."
+    "effect": "Attracts Pokemon in the wild."
   },
   {
     "name": "Lure Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/lure-ball.png",
     "category": "Pokeballs",
-    "effect": "A Pok\u00e9 Ball for catching Pok\u00e9mon hooked by a Rod when fishing."
+    "effect": "A Poke Ball for catching Pokemon hooked by a Rod when fishing."
   },
   {
     "name": "Lustrous Orb",
@@ -1845,7 +1845,7 @@
     "name": "Luxury Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/luxury-ball.png",
     "category": "Pokeballs",
-    "effect": "A comfortable Pok\u00e9 Ball that makes a caught wild Pok\u00e9mon quickly grow friendly."
+    "effect": "A comfortable Poke Ball that makes a caught wild Pokemon quickly grow friendly."
   },
   {
     "name": "Lycanium Z",
@@ -1857,7 +1857,7 @@
     "name": "Macho Brace",
     "imageurl": "https://img.pokemondb.net/sprites/items/macho-brace.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. It is a stiff and heavy brace that promotes strong growth but lowers Speed."
+    "effect": "An item to be held by a Pokemon. It is a stiff and heavy brace that promotes strong growth but lowers Speed."
   },
   {
     "name": "Magmarizer",
@@ -1893,7 +1893,7 @@
     "name": "Maranga Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/maranga-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, this Berry will increase the holder's Sp. Def if it's hit with a special move."
+    "effect": "If held by a Pokemon, this Berry will increase the holder's Sp. Def if it's hit with a special move."
   },
   {
     "name": "Marble",
@@ -1911,7 +1911,7 @@
     "name": "Master Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/master-ball.png",
     "category": "Pokeballs",
-    "effect": "The best Ball with the ultimate level of performance. It will catch any wild Pok\u00e9mon without fail."
+    "effect": "The best Ball with the ultimate level of performance. It will catch any wild Pokemon without fail."
   },
   {
     "name": "Mawilite",
@@ -1923,19 +1923,19 @@
     "name": "Max Elixir",
     "imageurl": "https://img.pokemondb.net/sprites/items/max-elixir.png",
     "category": "Medicine",
-    "effect": "It fully restores the PP of all the moves learned by the targeted Pok\u00e9mon."
+    "effect": "It fully restores the PP of all the moves learned by the targeted Pokemon."
   },
   {
     "name": "Max Ether",
     "imageurl": "https://img.pokemondb.net/sprites/items/max-ether.png",
     "category": "Medicine",
-    "effect": "It fully restores the PP of a single selected move that has been learned by the target Pok\u00e9mon."
+    "effect": "It fully restores the PP of a single selected move that has been learned by the target Pokemon."
   },
   {
     "name": "Max Lure",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "General items",
-    "effect": "Attracts Pok\u00e9mon in the wild."
+    "effect": "Attracts Pokemon in the wild."
   },
   {
     "name": "Max Potion",
@@ -1947,13 +1947,13 @@
     "name": "Max Repel",
     "imageurl": "https://img.pokemondb.net/sprites/items/max-repel.png",
     "category": "General items",
-    "effect": "An item that prevents weak wild Pok\u00e9mon from appearing for 250 steps after its use."
+    "effect": "An item that prevents weak wild Pokemon from appearing for 250 steps after its use."
   },
   {
     "name": "Max Revive",
     "imageurl": "https://img.pokemondb.net/sprites/items/max-revive.png",
     "category": "Medicine",
-    "effect": "A medicine that revives a fainted Pok\u00e9mon. It fully restores the Pok\u00e9mon's HP."
+    "effect": "A medicine that revives a fainted Pokemon. It fully restores the Pokemon's HP."
   },
   {
     "name": "Meadow Plate",
@@ -1971,7 +1971,7 @@
     "name": "Mental Herb",
     "imageurl": "https://img.pokemondb.net/sprites/items/mental-herb.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. It snaps the holder out of infatuation. It can be used only once."
+    "effect": "An item to be held by a Pokemon. It snaps the holder out of infatuation. It can be used only once."
   },
   {
     "name": "Metagrossite",
@@ -2025,25 +2025,25 @@
     "name": "Mighty Candy",
     "imageurl": "https://img.pokemondb.net/sprites/items/mighty-candy.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Attack stat by 1."
+    "effect": "Increases a Pokemon's Attack stat by 1."
   },
   {
     "name": "Mighty Candy L",
     "imageurl": "https://img.pokemondb.net/sprites/items/mighty-candy-l.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Attack stat."
+    "effect": "Increases a Pokemon's Attack stat."
   },
   {
     "name": "Mighty Candy XL",
     "imageurl": "https://img.pokemondb.net/sprites/items/mighty-candy-xl.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Attack stat."
+    "effect": "Increases a Pokemon's Attack stat."
   },
   {
     "name": "Mild Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Mild nature."
+    "effect": "Changes the Pokemon's stats to match the Mild nature."
   },
   {
     "name": "Mimikium Z",
@@ -2067,31 +2067,31 @@
     "name": "Misty Seed",
     "imageurl": "https://img.pokemondb.net/sprites/items/misty-seed.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. It boosts Sp. Def on Misty Terrain. It can only be used once."
+    "effect": "An item to be held by a Pokemon. It boosts Sp. Def on Misty Terrain. It can only be used once."
   },
   {
     "name": "Modest Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Modest nature."
+    "effect": "Changes the Pokemon's stats to match the Modest nature."
   },
   {
     "name": "Moomoo Milk",
     "imageurl": "https://img.pokemondb.net/sprites/items/moomoo-milk.png",
     "category": "Medicine",
-    "effect": "Milk with a very high nutrition content. It restores the HP of one Pok\u00e9mon by 100 points."
+    "effect": "Milk with a very high nutrition content. It restores the HP of one Pokemon by 100 points."
   },
   {
     "name": "Moon Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/moon-ball.png",
     "category": "Pokeballs",
-    "effect": "A Pok\u00e9 Ball for catching Pok\u00e9mon that evolve using the Moon Stone."
+    "effect": "A Poke Ball for catching Pokemon that evolve using the Moon Stone."
   },
   {
     "name": "Moon Stone",
     "imageurl": "https://img.pokemondb.net/sprites/items/moon-stone.png",
     "category": "General items",
-    "effect": "Evolves certain species of Pok\u00e9mon."
+    "effect": "Evolves certain species of Pokemon."
   },
   {
     "name": "Muscle Band",
@@ -2115,31 +2115,31 @@
     "name": "Naive Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Naive nature."
+    "effect": "Changes the Pokemon's stats to match the Naive nature."
   },
   {
     "name": "Nanab Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/nanab-berry.png",
     "category": "Berries",
-    "effect": "A Berry to be used in cooking. Calms a Pok\u00e9mon in battle, in Let's Go Pikachu/Eevee."
+    "effect": "A Berry to be used in cooking. Calms a Pokemon in battle, in Let's Go Pikachu/Eevee."
   },
   {
     "name": "Naughty Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Naughty nature."
+    "effect": "Changes the Pokemon's stats to match the Naughty nature."
   },
   {
     "name": "Nest Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/nest-ball.png",
     "category": "Pokeballs",
-    "effect": "A somewhat different Pok\u00e9 Ball that works especially well on weaker Pok\u00e9mon in the wild."
+    "effect": "A somewhat different Poke Ball that works especially well on weaker Pokemon in the wild."
   },
   {
     "name": "Net Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/net-ball.png",
     "category": "Pokeballs",
-    "effect": "A somewhat different Pok\u00e9 Ball that works especially well on Water- and Bug-type Pok\u00e9mon."
+    "effect": "A somewhat different Poke Ball that works especially well on Water- and Bug-type Pokemon."
   },
   {
     "name": "Never-Melt Ice",
@@ -2175,7 +2175,7 @@
     "name": "Occa Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/occa-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Fire-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Fire-type attack against the holding Pokemon."
   },
   {
     "name": "Odd Incense",
@@ -2193,7 +2193,7 @@
     "name": "Old Amber",
     "imageurl": "https://img.pokemondb.net/sprites/items/old-amber.png",
     "category": "General items",
-    "effect": "A piece of amber that contains the genetic material of an ancient Pok\u00e9mon. It is clear with a reddish tint."
+    "effect": "A piece of amber that contains the genetic material of an ancient Pokemon. It is clear with a reddish tint."
   },
   {
     "name": "Old Gateau",
@@ -2205,13 +2205,13 @@
     "name": "Oran Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/oran-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, it heals the user by just 10 HP."
+    "effect": "If held by a Pokemon, it heals the user by just 10 HP."
   },
   {
     "name": "Oval Charm",
     "imageurl": "https://img.pokemondb.net/sprites/items/oval-charm.png",
     "category": "General items",
-    "effect": "An oval charm said to increase the chance of Pok\u00e9mon Eggs being found at the Day Care."
+    "effect": "An oval charm said to increase the chance of Pokemon Eggs being found at the Day Care."
   },
   {
     "name": "Oval Stone",
@@ -2235,13 +2235,13 @@
     "name": "Paralyze Heal",
     "imageurl": "https://img.pokemondb.net/sprites/items/paralyze-heal.png",
     "category": "Medicine",
-    "effect": "A spray-type medicine. It eliminates paralysis from a single Pok\u00e9mon."
+    "effect": "A spray-type medicine. It eliminates paralysis from a single Pokemon."
   },
   {
     "name": "Park Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/park-ball.png",
     "category": "Pokeballs",
-    "effect": "A special Pok\u00e9 Ball for the Pal Park."
+    "effect": "A special Poke Ball for the Pal Park."
   },
   {
     "name": "Pass Orb",
@@ -2253,13 +2253,13 @@
     "name": "Passho Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/passho-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Water-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Water-type attack against the holding Pokemon."
   },
   {
     "name": "Payapa Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/payapa-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Psychic-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Psychic-type attack against the holding Pokemon."
   },
   {
     "name": "Pearl",
@@ -2277,7 +2277,7 @@
     "name": "Pecha Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/pecha-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, it recovers from poison."
+    "effect": "If held by a Pokemon, it recovers from poison."
   },
   {
     "name": "Permit",
@@ -2289,7 +2289,7 @@
     "name": "Persim Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/persim-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, it recovers from confusion."
+    "effect": "If held by a Pokemon, it recovers from confusion."
   },
   {
     "name": "Petaya Berry",
@@ -2325,7 +2325,7 @@
     "name": "Pinap Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/pinap-berry.png",
     "category": "Berries",
-    "effect": "A Berry to be used in cooking. Increases chances of getting items when a Pok\u00e9mon is caught, in Pok\u00e9mon Let's Go."
+    "effect": "A Berry to be used in cooking. Increases chances of getting items when a Pokemon is caught, in Pokemon Let's Go."
   },
   {
     "name": "Pink Apricorn",
@@ -2337,7 +2337,7 @@
     "name": "Pink Nectar",
     "imageurl": "https://img.pokemondb.net/sprites/items/pink-nectar.png",
     "category": "Hold items",
-    "effect": "The flower nectar obtained at the flowering shrubs on Royal Avenue. It changes the form of certain species of Pok\u00e9mon."
+    "effect": "The flower nectar obtained at the flowering shrubs on Royal Avenue. It changes the form of certain species of Pokemon."
   },
   {
     "name": "Pink Scarf",
@@ -2367,7 +2367,7 @@
     "name": "Plume Fossil",
     "imageurl": "https://img.pokemondb.net/sprites/items/plume-fossil.png",
     "category": "General items",
-    "effect": "A fossil of an ancient Pok\u00e9mon that flew in the sky in ancient times. It appears to be part of its wing."
+    "effect": "A fossil of an ancient Pokemon that flew in the sky in ancient times. It appears to be part of its wing."
   },
   {
     "name": "Poison Barb",
@@ -2394,22 +2394,22 @@
     "effect": "Allows the use of Acid Downpour, the Poison type Z-Move."
   },
   {
-    "name": "Pok\u00e9 Ball",
+    "name": "Poke Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/poke-ball.png",
     "category": "Pokeballs",
-    "effect": "A device for catching wild Pok\u00e9mon. It is thrown like a ball at the target. It is designed as a capsule system."
+    "effect": "A device for catching wild Pokemon. It is thrown like a ball at the target. It is designed as a capsule system."
   },
   {
-    "name": "Pok\u00e9 Doll",
+    "name": "Poke Doll",
     "imageurl": "https://img.pokemondb.net/sprites/items/poke-doll.png",
     "category": "General items",
-    "effect": "A doll that attracts Pok\u00e9mon. Use it to flee from any battle with a wild Pok\u00e9mon."
+    "effect": "A doll that attracts Pokemon. Use it to flee from any battle with a wild Pokemon."
   },
   {
-    "name": "Pok\u00e9 Toy",
+    "name": "Poke Toy",
     "imageurl": "https://img.pokemondb.net/sprites/items/poke-toy.png",
     "category": "General items",
-    "effect": "An item that attracts Pok\u00e9mon. Use it to flee from any battle with a wild Pok\u00e9mon."
+    "effect": "An item that attracts Pokemon. Use it to flee from any battle with a wild Pokemon."
   },
   {
     "name": "Polished Mud Ball",
@@ -2433,37 +2433,37 @@
     "name": "Power Anklet",
     "imageurl": "https://img.pokemondb.net/sprites/items/power-anklet.png",
     "category": "Hold items",
-    "effect": "A Pok\u00e9mon held item that promotes Speed gain on leveling, but reduces the Speed stat."
+    "effect": "A Pokemon held item that promotes Speed gain on leveling, but reduces the Speed stat."
   },
   {
     "name": "Power Band",
     "imageurl": "https://img.pokemondb.net/sprites/items/power-band.png",
     "category": "Hold items",
-    "effect": "A Pok\u00e9mon held item that promotes Sp. Def gain on leveling, but reduces the Speed stat."
+    "effect": "A Pokemon held item that promotes Sp. Def gain on leveling, but reduces the Speed stat."
   },
   {
     "name": "Power Belt",
     "imageurl": "https://img.pokemondb.net/sprites/items/power-belt.png",
     "category": "Hold items",
-    "effect": "A Pok\u00e9mon held item that promotes Defense gain on leveling, but reduces the Speed stat."
+    "effect": "A Pokemon held item that promotes Defense gain on leveling, but reduces the Speed stat."
   },
   {
     "name": "Power Bracer",
     "imageurl": "https://img.pokemondb.net/sprites/items/power-bracer.png",
     "category": "Hold items",
-    "effect": "A Pok\u00e9mon held item that promotes Attack gain on leveling, but reduces the Speed stat."
+    "effect": "A Pokemon held item that promotes Attack gain on leveling, but reduces the Speed stat."
   },
   {
     "name": "Power Herb",
     "imageurl": "https://img.pokemondb.net/sprites/items/power-herb.png",
     "category": "Hold items",
-    "effect": "A single-use item to be held by a Pok\u00e9mon. It allows the immediate use of a move that charges on the first turn."
+    "effect": "A single-use item to be held by a Pokemon. It allows the immediate use of a move that charges on the first turn."
   },
   {
     "name": "Power Lens",
     "imageurl": "https://img.pokemondb.net/sprites/items/power-lens.png",
     "category": "Hold items",
-    "effect": "A Pok\u00e9mon held item that promotes Sp. Atk gain on leveling, but reduces the Speed stat."
+    "effect": "A Pokemon held item that promotes Sp. Atk gain on leveling, but reduces the Speed stat."
   },
   {
     "name": "Power Plant Pass",
@@ -2475,31 +2475,31 @@
     "name": "Power Weight",
     "imageurl": "https://img.pokemondb.net/sprites/items/power-weight.png",
     "category": "Hold items",
-    "effect": "A Pok\u00e9mon held item that promotes HP gain on leveling, but reduces the Speed stat."
+    "effect": "A Pokemon held item that promotes HP gain on leveling, but reduces the Speed stat."
   },
   {
     "name": "PP Max",
     "imageurl": "https://img.pokemondb.net/sprites/items/pp-max.png",
     "category": "Medicine",
-    "effect": "It maximally raises the top PP of a selected move that has been learned by the target Pok\u00e9mon."
+    "effect": "It maximally raises the top PP of a selected move that has been learned by the target Pokemon."
   },
   {
     "name": "PP Up",
     "imageurl": "https://img.pokemondb.net/sprites/items/pp-up.png",
     "category": "Medicine",
-    "effect": "It slightly raises the maximum PP of a selected move that has been learned by the target Pok\u00e9mon."
+    "effect": "It slightly raises the maximum PP of a selected move that has been learned by the target Pokemon."
   },
   {
     "name": "Premier Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/premier-ball.png",
     "category": "Pokeballs",
-    "effect": "A somewhat rare Pok\u00e9 Ball that has been specially made to commemorate an event of some sort."
+    "effect": "A somewhat rare Poke Ball that has been specially made to commemorate an event of some sort."
   },
   {
     "name": "Pretty Wing",
     "imageurl": "https://img.pokemondb.net/sprites/items/pretty-wing.png",
     "category": "General items",
-    "effect": "Though this feather is beautiful, it's just a regular feather and has no effect on Pok\u00e9mon."
+    "effect": "Though this feather is beautiful, it's just a regular feather and has no effect on Pokemon."
   },
   {
     "name": "Primarium Z",
@@ -2529,7 +2529,7 @@
     "name": "Protective Pads",
     "imageurl": "https://img.pokemondb.net/sprites/items/protective-pads.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. These pads protect the holder from effects caused by making direct contact with the target."
+    "effect": "An item to be held by a Pokemon. These pads protect the holder from effects caused by making direct contact with the target."
   },
   {
     "name": "Protector",
@@ -2559,7 +2559,7 @@
     "name": "Psychic Seed",
     "imageurl": "https://img.pokemondb.net/sprites/items/psychic-seed.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. It boosts Sp. Def on Psychic Terrain. It can only be used once."
+    "effect": "An item to be held by a Pokemon. It boosts Sp. Def on Psychic Terrain. It can only be used once."
   },
   {
     "name": "Psychium Z",
@@ -2577,13 +2577,13 @@
     "name": "Pure Incense",
     "imageurl": "https://img.pokemondb.net/sprites/items/pure-incense.png",
     "category": "Hold items",
-    "effect": "Descreases the likelihood of meeting wild Pok\u00e9mon. Breeding Chimecho produces Chingling when held."
+    "effect": "Descreases the likelihood of meeting wild Pokemon. Breeding Chimecho produces Chingling when held."
   },
   {
     "name": "Purple Nectar",
     "imageurl": "https://img.pokemondb.net/sprites/items/purple-nectar.png",
     "category": "Hold items",
-    "effect": "A flower nectar obtained at Poni Meadow. It changes the form of certain species of Pok\u00e9mon."
+    "effect": "A flower nectar obtained at Poni Meadow. It changes the form of certain species of Pokemon."
   },
   {
     "name": "Qualot Berry",
@@ -2595,31 +2595,31 @@
     "name": "Quick Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/quick-ball.png",
     "category": "Pokeballs",
-    "effect": "A somewhat different Pok\u00e9 Ball that provides a better catch rate if it is used at the start of a wild encounter."
+    "effect": "A somewhat different Poke Ball that provides a better catch rate if it is used at the start of a wild encounter."
   },
   {
     "name": "Quick Candy",
     "imageurl": "https://img.pokemondb.net/sprites/items/quick-candy.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Speed stat by 1."
+    "effect": "Increases a Pokemon's Speed stat by 1."
   },
   {
     "name": "Quick Candy L",
     "imageurl": "https://img.pokemondb.net/sprites/items/quick-candy-l.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Speed stat."
+    "effect": "Increases a Pokemon's Speed stat."
   },
   {
     "name": "Quick Candy XL",
     "imageurl": "https://img.pokemondb.net/sprites/items/quick-candy-xl.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Speed stat."
+    "effect": "Increases a Pokemon's Speed stat."
   },
   {
     "name": "Quick Claw",
     "imageurl": "https://img.pokemondb.net/sprites/items/quick-claw.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. A light, sharp claw that lets the bearer move first occasionally."
+    "effect": "An item to be held by a Pokemon. A light, sharp claw that lets the bearer move first occasionally."
   },
   {
     "name": "Quick Powder",
@@ -2631,7 +2631,7 @@
     "name": "Quiet Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Quiet nature."
+    "effect": "Changes the Pokemon's stats to match the Quiet nature."
   },
   {
     "name": "Rabuta Berry",
@@ -2649,25 +2649,25 @@
     "name": "Rare Bone",
     "imageurl": "https://img.pokemondb.net/sprites/items/rare-bone.png",
     "category": "General items",
-    "effect": "A bone that is extremely valuable for Pok\u00e9mon archeology. It can be sold for a high price to shops."
+    "effect": "A bone that is extremely valuable for Pokemon archeology. It can be sold for a high price to shops."
   },
   {
     "name": "Rare Candy",
     "imageurl": "https://img.pokemondb.net/sprites/items/rare-candy.png",
     "category": "Medicine",
-    "effect": "A candy that is packed with energy. It raises the level of a single Pok\u00e9mon by one."
+    "effect": "A candy that is packed with energy. It raises the level of a single Pokemon by one."
   },
   {
     "name": "Rash Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Rash nature."
+    "effect": "Changes the Pokemon's stats to match the Rash nature."
   },
   {
     "name": "Rawst Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/rawst-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, it recovers from a burn."
+    "effect": "If held by a Pokemon, it recovers from a burn."
   },
   {
     "name": "Razor Claw",
@@ -2715,7 +2715,7 @@
     "name": "Red Nectar",
     "imageurl": "https://img.pokemondb.net/sprites/items/red-nectar.png",
     "category": "Hold items",
-    "effect": "A flower nectar obtained at Ula'ula Meadow. It changes the form of certain species of Pok\u00e9mon."
+    "effect": "A flower nectar obtained at Ula'ula Meadow. It changes the form of certain species of Pokemon."
   },
   {
     "name": "Red Scarf",
@@ -2733,7 +2733,7 @@
     "name": "Relaxed Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Relaxed nature."
+    "effect": "Changes the Pokemon's stats to match the Relaxed nature."
   },
   {
     "name": "Relic Band",
@@ -2781,19 +2781,19 @@
     "name": "Repeat Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/repeat-ball.png",
     "category": "Pokeballs",
-    "effect": "A somewhat different Pok\u00e9 Ball that works especially well on Pok\u00e9mon species that were previously caught."
+    "effect": "A somewhat different Poke Ball that works especially well on Pokemon species that were previously caught."
   },
   {
     "name": "Repel",
     "imageurl": "https://img.pokemondb.net/sprites/items/repel.png",
     "category": "General items",
-    "effect": "An item that prevents weak wild Pok\u00e9mon from appearing for 100 steps after its use."
+    "effect": "An item that prevents weak wild Pokemon from appearing for 100 steps after its use."
   },
   {
     "name": "Reset Urge",
     "imageurl": "https://img.pokemondb.net/sprites/items/reset-urge.png",
     "category": "Battle items",
-    "effect": "When used, it restores any stat changes of an ally Pok\u00e9mon."
+    "effect": "When used, it restores any stat changes of an ally Pokemon."
   },
   {
     "name": "Resist Wing",
@@ -2805,31 +2805,31 @@
     "name": "Reveal Glass",
     "imageurl": "https://img.pokemondb.net/sprites/items/reveal-glass.png",
     "category": "General items",
-    "effect": "A looking glass that reveals the truth. It's a mysterious glass that returns a Pok\u00e9mon to its original shape."
+    "effect": "A looking glass that reveals the truth. It's a mysterious glass that returns a Pokemon to its original shape."
   },
   {
     "name": "Revival Herb",
     "imageurl": "https://img.pokemondb.net/sprites/items/revival-herb.png",
     "category": "Medicine",
-    "effect": "Revives a Pok\u00e9mon to max HP, but lowers Friendship."
+    "effect": "Revives a Pokemon to max HP, but lowers Friendship."
   },
   {
     "name": "Revive",
     "imageurl": "https://img.pokemondb.net/sprites/items/revive.png",
     "category": "Medicine",
-    "effect": "A medicine that revives a fainted Pok\u00e9mon. It restores half the Pok\u00e9mon's maximum HP."
+    "effect": "A medicine that revives a fainted Pokemon. It restores half the Pokemon's maximum HP."
   },
   {
     "name": "Rindo Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/rindo-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Grass-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Grass-type attack against the holding Pokemon."
   },
   {
     "name": "Ring Target",
     "imageurl": "https://img.pokemondb.net/sprites/items/ring-target.png",
     "category": "Hold items",
-    "effect": "Moves that would otherwise have no effect will land on the Pok\u00e9mon that holds it."
+    "effect": "Moves that would otherwise have no effect will land on the Pokemon that holds it."
   },
   {
     "name": "Rock Gem",
@@ -2871,13 +2871,13 @@
     "name": "Room Service",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Hold items",
-    "effect": "Lowers the Pok\u00e9mon's speed during Trick Room."
+    "effect": "Lowers the Pokemon's speed during Trick Room."
   },
   {
     "name": "Root Fossil",
     "imageurl": "https://img.pokemondb.net/sprites/items/root-fossil.png",
     "category": "General items",
-    "effect": "A fossil of an ancient Pok\u00e9mon that lived in the sea. It appears to be part of a plant root."
+    "effect": "A fossil of an ancient Pokemon that lived in the sea. It appears to be part of a plant root."
   },
   {
     "name": "Rose Incense",
@@ -2889,43 +2889,43 @@
     "name": "Roseli Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/roseli-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, this Berry will lessen the damage taken from one supereffective Fairy-type attack."
+    "effect": "If held by a Pokemon, this Berry will lessen the damage taken from one supereffective Fairy-type attack."
   },
   {
     "name": "Roto Bargain",
     "imageurl": "https://img.pokemondb.net/sprites/items/roto-bargain.png",
     "category": "Battle items",
-    "effect": "Reduces the prices of products at Pok\u00e9 Marts by half."
+    "effect": "Reduces the prices of products at Poke Marts by half."
   },
   {
     "name": "Roto Boost",
     "imageurl": "https://img.pokemondb.net/sprites/items/roto-boost.png",
     "category": "Battle items",
-    "effect": "Raises all stats of your battling Pok\u00e9mon."
+    "effect": "Raises all stats of your battling Pokemon."
   },
   {
     "name": "Roto Catch",
     "imageurl": "https://img.pokemondb.net/sprites/items/roto-catch.png",
     "category": "Battle items",
-    "effect": "Increases the chance to catch Pok\u00e9mon a lot."
+    "effect": "Increases the chance to catch Pokemon a lot."
   },
   {
     "name": "Roto Encounter",
     "imageurl": "https://img.pokemondb.net/sprites/items/roto-encounter.png",
     "category": "Battle items",
-    "effect": "Increases the chance of encountering high-level wild Pok\u00e9mon a lot for a certain period of time."
+    "effect": "Increases the chance of encountering high-level wild Pokemon a lot for a certain period of time."
   },
   {
     "name": "Roto Exp. Points",
     "imageurl": "https://img.pokemondb.net/sprites/items/roto-exp-points.png",
     "category": "Battle items",
-    "effect": "Increases the Exp. Points your Pok\u00e9mon receive after battle a little."
+    "effect": "Increases the Exp. Points your Pokemon receive after battle a little."
   },
   {
     "name": "Roto Friendship",
     "imageurl": "https://img.pokemondb.net/sprites/items/roto-friendship.png",
     "category": "Battle items",
-    "effect": "Helps Pok\u00e9mon in your party grow friendly faster."
+    "effect": "Helps Pokemon in your party grow friendly faster."
   },
   {
     "name": "Roto Hatch",
@@ -2937,13 +2937,13 @@
     "name": "Roto HP Restore",
     "imageurl": "https://img.pokemondb.net/sprites/items/roto-hp-restore.png",
     "category": "Battle items",
-    "effect": "Fully restores the HP of your battling Pok\u00e9mon."
+    "effect": "Fully restores the HP of your battling Pokemon."
   },
   {
     "name": "Roto PP Restore",
     "imageurl": "https://img.pokemondb.net/sprites/items/roto-pp-restore.png",
     "category": "Battle items",
-    "effect": "Fully restores the PP of your battling Pok\u00e9mon."
+    "effect": "Fully restores the PP of your battling Pokemon."
   },
   {
     "name": "Roto Prize Money",
@@ -2955,13 +2955,13 @@
     "name": "Roto Stealth",
     "imageurl": "https://img.pokemondb.net/sprites/items/roto-stealth.png",
     "category": "Battle items",
-    "effect": "Prevents you from encountering wild Pok\u00e9mon for a certain period of time."
+    "effect": "Prevents you from encountering wild Pokemon for a certain period of time."
   },
   {
     "name": "Rowap Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/rowap-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon and a special attack lands, the attacker also takes damage."
+    "effect": "If held by a Pokemon and a special attack lands, the attacker also takes damage."
   },
   {
     "name": "Sablenite",
@@ -2979,13 +2979,13 @@
     "name": "Sacred Ash",
     "imageurl": "https://img.pokemondb.net/sprites/items/sacred-ash.png",
     "category": "Medicine",
-    "effect": "It revives all fainted Pok\u00e9mon. In doing so, it also fully restores their HP."
+    "effect": "It revives all fainted Pokemon. In doing so, it also fully restores their HP."
   },
   {
     "name": "Safari Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/safari-ball.png",
     "category": "Pokeballs",
-    "effect": "A special Pok\u00e9 Ball that is used only in the Great Marsh. It is decorated in a camouflage pattern."
+    "effect": "A special Poke Ball that is used only in the Great Marsh. It is decorated in a camouflage pattern."
   },
   {
     "name": "Safety Goggles",
@@ -3009,7 +3009,7 @@
     "name": "Sassy Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Sassy nature."
+    "effect": "Changes the Pokemon's stats to match the Sassy nature."
   },
   {
     "name": "Sceptilite",
@@ -3057,25 +3057,25 @@
     "name": "Shed Shell",
     "imageurl": "https://img.pokemondb.net/sprites/items/shed-shell.png",
     "category": "Hold items",
-    "effect": "A tough, discarded carapace to be held by a Pok\u00e9mon. It enables the holder to switch with a waiting Pok\u00e9mon in battle."
+    "effect": "A tough, discarded carapace to be held by a Pokemon. It enables the holder to switch with a waiting Pokemon in battle."
   },
   {
     "name": "Shell Bell",
     "imageurl": "https://img.pokemondb.net/sprites/items/shell-bell.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. The holder's HP is restored a little every time it inflicts damage."
+    "effect": "An item to be held by a Pokemon. The holder's HP is restored a little every time it inflicts damage."
   },
   {
     "name": "Shiny Charm",
     "imageurl": "https://img.pokemondb.net/sprites/items/shiny-charm.png",
     "category": "General items",
-    "effect": "A shiny charm said to increase the chance of finding a Shiny Pok\u00e9mon in the wild."
+    "effect": "A shiny charm said to increase the chance of finding a Shiny Pokemon in the wild."
   },
   {
     "name": "Shiny Stone",
     "imageurl": "https://img.pokemondb.net/sprites/items/shiny-stone.png",
     "category": "General items",
-    "effect": "Evolves certain species of Pok\u00e9mon."
+    "effect": "Evolves certain species of Pokemon."
   },
   {
     "name": "Shoal Salt",
@@ -3099,7 +3099,7 @@
     "name": "Shuca Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/shuca-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Ground-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Ground-type attack against the holding Pokemon."
   },
   {
     "name": "Silk Scarf",
@@ -3117,13 +3117,13 @@
     "name": "Silver Nanab Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/silver-nanab-berry.png",
     "category": "Berries",
-    "effect": "Greatly calms a Pok\u00e9mon in battle, in Let's Go Pikachu/Eevee."
+    "effect": "Greatly calms a Pokemon in battle, in Let's Go Pikachu/Eevee."
   },
   {
     "name": "Silver Pinap Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/silver-pinap-berry.png",
     "category": "Berries",
-    "effect": "Greatly increases chance of getting items when a Pok\u00e9mon is caught, in Pok\u00e9mon Let's Go."
+    "effect": "Greatly increases chance of getting items when a Pokemon is caught, in Pokemon Let's Go."
   },
   {
     "name": "Silver Powder",
@@ -3135,19 +3135,19 @@
     "name": "Silver Razz Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/silver-razz-berry.png",
     "category": "Berries",
-    "effect": "Makes a Pok\u00e9mon easier to catch in Pok\u00e9mon Let's Go."
+    "effect": "Makes a Pokemon easier to catch in Pokemon Let's Go."
   },
   {
     "name": "Sitrus Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/sitrus-berry.png",
     "category": "Berries",
-    "effect": "If held by a Pok\u00e9mon, it heals the user's HP a little."
+    "effect": "If held by a Pokemon, it heals the user's HP a little."
   },
   {
     "name": "Skull Fossil",
     "imageurl": "https://img.pokemondb.net/sprites/items/skull-fossil.png",
     "category": "General items",
-    "effect": "A fossil from a prehistoric Pok\u00e9mon that lived on the land. It appears to be part of a head."
+    "effect": "A fossil from a prehistoric Pokemon that lived on the land. It appears to be part of a head."
   },
   {
     "name": "Sky Plate",
@@ -3171,31 +3171,31 @@
     "name": "Smart Candy",
     "imageurl": "https://img.pokemondb.net/sprites/items/smart-candy.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Special Attack stat by 1."
+    "effect": "Increases a Pokemon's Special Attack stat by 1."
   },
   {
     "name": "Smart Candy L",
     "imageurl": "https://img.pokemondb.net/sprites/items/smart-candy-l.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Special Attack stat."
+    "effect": "Increases a Pokemon's Special Attack stat."
   },
   {
     "name": "Smart Candy XL",
     "imageurl": "https://img.pokemondb.net/sprites/items/smart-candy-xl.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Special Attack stat."
+    "effect": "Increases a Pokemon's Special Attack stat."
   },
   {
     "name": "Smoke Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/smoke-ball.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. It enables the holder to flee from any wild Pok\u00e9mon without fail."
+    "effect": "An item to be held by a Pokemon. It enables the holder to flee from any wild Pokemon without fail."
   },
   {
     "name": "Smooth Rock",
     "imageurl": "https://img.pokemondb.net/sprites/items/smooth-rock.png",
     "category": "Hold items",
-    "effect": "A Pok\u00e9mon held item that extends the duration of the move Sandstorm used by the holder."
+    "effect": "A Pokemon held item that extends the duration of the move Sandstorm used by the holder."
   },
   {
     "name": "Snorlium Z",
@@ -3231,7 +3231,7 @@
     "name": "Soothe Bell",
     "imageurl": "https://img.pokemondb.net/sprites/items/soothe-bell.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. It is a bell with a comforting chime that calms the holder and makes it friendly."
+    "effect": "An item to be held by a Pokemon. It is a bell with a comforting chime that calms the holder and makes it friendly."
   },
   {
     "name": "Soul Dew",
@@ -3267,7 +3267,7 @@
     "name": "Sport Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/sport-ball.png",
     "category": "Pokeballs",
-    "effect": "A special Pok\u00e9 Ball for the Bug-Catching Contest."
+    "effect": "A special Poke Ball for the Bug-Catching Contest."
   },
   {
     "name": "Sprinklotad",
@@ -3351,7 +3351,7 @@
     "name": "Strange Souvenir",
     "imageurl": "https://img.pokemondb.net/sprites/items/strange-souvenir.png",
     "category": "General items",
-    "effect": "An ornament depicting a Pok\u00e9mon that is venerated as a protector in some region far from Kalos."
+    "effect": "An ornament depicting a Pokemon that is venerated as a protector in some region far from Kalos."
   },
   {
     "name": "Strawberry Sweet",
@@ -3369,13 +3369,13 @@
     "name": "Sun Stone",
     "imageurl": "https://img.pokemondb.net/sprites/items/sun-stone.png",
     "category": "General items",
-    "effect": "Evolves certain species of Pok\u00e9mon."
+    "effect": "Evolves certain species of Pokemon."
   },
   {
     "name": "Super Lure",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "General items",
-    "effect": "Attracts Pok\u00e9mon in the wild."
+    "effect": "Attracts Pokemon in the wild."
   },
   {
     "name": "Super Potion",
@@ -3387,7 +3387,7 @@
     "name": "Super Repel",
     "imageurl": "https://img.pokemondb.net/sprites/items/super-repel.png",
     "category": "General items",
-    "effect": "An item that prevents weak wild Pok\u00e9mon from appearing for 200 steps after its use."
+    "effect": "An item that prevents weak wild Pokemon from appearing for 200 steps after its use."
   },
   {
     "name": "Swampertite",
@@ -3405,7 +3405,7 @@
     "name": "Sweet Heart",
     "imageurl": "https://img.pokemondb.net/sprites/items/sweet-heart.png",
     "category": "Medicine",
-    "effect": "Very sweet chocolate. It restores the HP of one Pok\u00e9mon by only 20 points."
+    "effect": "Very sweet chocolate. It restores the HP of one Pokemon by only 20 points."
   },
   {
     "name": "Swift Wing",
@@ -3423,7 +3423,7 @@
     "name": "Tanga Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/tanga-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Bug-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Bug-type attack against the holding Pokemon."
   },
   {
     "name": "Tapunium Z",
@@ -3435,7 +3435,7 @@
     "name": "Terrain Extender",
     "imageurl": "https://img.pokemondb.net/sprites/items/terrain-extender.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. It extends the duration of the terrain caused by the holder's move or Ability."
+    "effect": "An item to be held by a Pokemon. It extends the duration of the terrain caused by the holder's move or Ability."
   },
   {
     "name": "Thick Club",
@@ -3453,7 +3453,7 @@
     "name": "Thunder Stone",
     "imageurl": "https://img.pokemondb.net/sprites/items/thunder-stone.png",
     "category": "General items",
-    "effect": "Evolves certain species of Pok\u00e9mon."
+    "effect": "Evolves certain species of Pokemon."
   },
   {
     "name": "Timer Ball",
@@ -3465,7 +3465,7 @@
     "name": "Timid Mint",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "Battle items",
-    "effect": "Changes the Pok\u00e9mon's stats to match the Timid nature."
+    "effect": "Changes the Pokemon's stats to match the Timid nature."
   },
   {
     "name": "Tiny Mushroom",
@@ -4083,25 +4083,25 @@
     "name": "Tough Candy",
     "imageurl": "https://img.pokemondb.net/sprites/items/tough-candy.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Defense stat by 1."
+    "effect": "Increases a Pokemon's Defense stat by 1."
   },
   {
     "name": "Tough Candy L",
     "imageurl": "https://img.pokemondb.net/sprites/items/tough-candy-l.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Defense stat."
+    "effect": "Increases a Pokemon's Defense stat."
   },
   {
     "name": "Tough Candy XL",
     "imageurl": "https://img.pokemondb.net/sprites/items/tough-candy-xl.png",
     "category": "Medicine",
-    "effect": "Increases a Pok\u00e9mon's Defense stat."
+    "effect": "Increases a Pokemon's Defense stat."
   },
   {
     "name": "Toxic Orb",
     "imageurl": "https://img.pokemondb.net/sprites/items/toxic-orb.png",
     "category": "Hold items",
-    "effect": "An item to be held by a Pok\u00e9mon. It is a bizarre orb that badly poisons the holder in battle."
+    "effect": "An item to be held by a Pokemon. It is a bizarre orb that badly poisons the holder in battle."
   },
   {
     "name": "Toxic Plate",
@@ -4731,7 +4731,7 @@
     "name": "Ultra Ball",
     "imageurl": "https://img.pokemondb.net/sprites/items/ultra-ball.png",
     "category": "Pokeballs",
-    "effect": "An ultra-performance Ball that provides a higher Pok\u00e9mon catch rate than a Great Ball."
+    "effect": "An ultra-performance Ball that provides a higher Pokemon catch rate than a Great Ball."
   },
   {
     "name": "Ultranecrozium Z",
@@ -4755,7 +4755,7 @@
     "name": "Wacan Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/wacan-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Electric-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Electric-type attack against the holding Pokemon."
   },
   {
     "name": "Water Gem",
@@ -4773,7 +4773,7 @@
     "name": "Water Stone",
     "imageurl": "https://img.pokemondb.net/sprites/items/water-stone.png",
     "category": "General items",
-    "effect": "Evolves certain species of Pok\u00e9mon."
+    "effect": "Evolves certain species of Pokemon."
   },
   {
     "name": "Waterium Z",
@@ -4827,7 +4827,7 @@
     "name": "White Herb",
     "imageurl": "https://img.pokemondb.net/sprites/items/white-herb.png",
     "category": "Hold items",
-    "effect": "An item to be held by a POK\u00e9MON. It restores any lowered stat in battle. It can be used only once."
+    "effect": "An item to be held by a Pokemon. It restores any lowered stat in battle. It can be used only once."
   },
   {
     "name": "Wide Lens",
@@ -4851,157 +4851,157 @@
     "name": "Wishing Piece",
     "imageurl": "https://img.pokemondb.net/s.png",
     "category": "General items",
-    "effect": "Activates a Pok\u00e9mon Den for a Max Raid Battle."
+    "effect": "Activates a Pokemon Den for a Max Raid Battle."
   },
   {
     "name": "X Accuracy",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-accuracy.png",
     "category": "Battle items",
-    "effect": "Raises Accuracy of a Pok\u00e9mon in battle."
+    "effect": "Raises Accuracy of a Pokemon in battle."
   },
   {
     "name": "X Accuracy 2",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-accuracy-2.png",
     "category": "Battle items",
-    "effect": "Sharply raises Accuracy of a Pok\u00e9mon in battle."
+    "effect": "Sharply raises Accuracy of a Pokemon in battle."
   },
   {
     "name": "X Accuracy 3",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-accuracy-3.png",
     "category": "Battle items",
-    "effect": "Drastically raises Accuracy of a Pok\u00e9mon in battle."
+    "effect": "Drastically raises Accuracy of a Pokemon in battle."
   },
   {
     "name": "X Accuracy 6",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-accuracy-6.png",
     "category": "Battle items",
-    "effect": "Immensely raises Accuracy of a Pok\u00e9mon in battle."
+    "effect": "Immensely raises Accuracy of a Pokemon in battle."
   },
   {
     "name": "X Attack",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-attack.png",
     "category": "Battle items",
-    "effect": "Raises Attack of a Pok\u00e9mon in battle."
+    "effect": "Raises Attack of a Pokemon in battle."
   },
   {
     "name": "X Attack 2",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-attack-2.png",
     "category": "Battle items",
-    "effect": "Sharply raises Attack of a Pok\u00e9mon in battle."
+    "effect": "Sharply raises Attack of a Pokemon in battle."
   },
   {
     "name": "X Attack 3",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-attack-3.png",
     "category": "Battle items",
-    "effect": "Drastically raises Attack of a Pok\u00e9mon in battle."
+    "effect": "Drastically raises Attack of a Pokemon in battle."
   },
   {
     "name": "X Attack 6",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-attack-6.png",
     "category": "Battle items",
-    "effect": "Immensely raises Attack of a Pok\u00e9mon in battle."
+    "effect": "Immensely raises Attack of a Pokemon in battle."
   },
   {
     "name": "X Defense",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-defense.png",
     "category": "Battle items",
-    "effect": "Raises Defense of a Pok\u00e9mon in battle."
+    "effect": "Raises Defense of a Pokemon in battle."
   },
   {
     "name": "X Defense 2",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-defense-2.png",
     "category": "Battle items",
-    "effect": "Sharply raises Defense of a Pok\u00e9mon in battle."
+    "effect": "Sharply raises Defense of a Pokemon in battle."
   },
   {
     "name": "X Defense 3",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-defense-3.png",
     "category": "Battle items",
-    "effect": "Drastically raises Defense of a Pok\u00e9mon in battle."
+    "effect": "Drastically raises Defense of a Pokemon in battle."
   },
   {
     "name": "X Defense 6",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-defense-6.png",
     "category": "Battle items",
-    "effect": "Immensely raises Defense of a Pok\u00e9mon in battle."
+    "effect": "Immensely raises Defense of a Pokemon in battle."
   },
   {
     "name": "X Sp. Atk",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-sp-atk.png",
     "category": "Battle items",
-    "effect": "Raises Special Attack of a Pok\u00e9mon in battle."
+    "effect": "Raises Special Attack of a Pokemon in battle."
   },
   {
     "name": "X Sp. Atk 2",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-sp-atk-2.png",
     "category": "Battle items",
-    "effect": "Sharply raises Special Attack of a Pok\u00e9mon in battle."
+    "effect": "Sharply raises Special Attack of a Pokemon in battle."
   },
   {
     "name": "X Sp. Atk 3",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-sp-atk-3.png",
     "category": "Battle items",
-    "effect": "Drastically raises Special Attack of a Pok\u00e9mon in battle."
+    "effect": "Drastically raises Special Attack of a Pokemon in battle."
   },
   {
     "name": "X Sp. Atk 6",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-sp-atk-6.png",
     "category": "Battle items",
-    "effect": "Immensely raises Special Attack of a Pok\u00e9mon in battle."
+    "effect": "Immensely raises Special Attack of a Pokemon in battle."
   },
   {
     "name": "X Sp. Def",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-sp-def.png",
     "category": "Battle items",
-    "effect": "Raises Special Defense of a Pok\u00e9mon in battle."
+    "effect": "Raises Special Defense of a Pokemon in battle."
   },
   {
     "name": "X Sp. Def 2",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-sp-def-2.png",
     "category": "Battle items",
-    "effect": "Sharply raises Special Defense of a Pok\u00e9mon in battle."
+    "effect": "Sharply raises Special Defense of a Pokemon in battle."
   },
   {
     "name": "X Sp. Def 3",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-sp-def-3.png",
     "category": "Battle items",
-    "effect": "Drastically raises Special Defense of a Pok\u00e9mon in battle."
+    "effect": "Drastically raises Special Defense of a Pokemon in battle."
   },
   {
     "name": "X Sp. Def 6",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-sp-def-6.png",
     "category": "Battle items",
-    "effect": "Immensely raises Special Defense of a Pok\u00e9mon in battle."
+    "effect": "Immensely raises Special Defense of a Pokemon in battle."
   },
   {
     "name": "X Speed",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-speed.png",
     "category": "Battle items",
-    "effect": "Raises Speed of a Pok\u00e9mon in battle."
+    "effect": "Raises Speed of a Pokemon in battle."
   },
   {
     "name": "X Speed 2",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-speed-2.png",
     "category": "Battle items",
-    "effect": "Sharply raises Speed of a Pok\u00e9mon in battle."
+    "effect": "Sharply raises Speed of a Pokemon in battle."
   },
   {
     "name": "X Speed 3",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-speed-3.png",
     "category": "Battle items",
-    "effect": "Drastically raises Speed of a Pok\u00e9mon in battle."
+    "effect": "Drastically raises Speed of a Pokemon in battle."
   },
   {
     "name": "X Speed 6",
     "imageurl": "https://img.pokemondb.net/sprites/items/x-speed-6.png",
     "category": "Battle items",
-    "effect": "Immensely raises Speed of a Pok\u00e9mon in battle."
+    "effect": "Immensely raises Speed of a Pokemon in battle."
   },
   {
     "name": "Yache Berry",
     "imageurl": "https://img.pokemondb.net/sprites/items/yache-berry.png",
     "category": "Berries",
-    "effect": "Weakens a supereffective Ice-type attack against the holding Pok\u00e9mon."
+    "effect": "Weakens a supereffective Ice-type attack against the holding Pokemon."
   },
   {
     "name": "Yellow Apricorn",
@@ -5019,7 +5019,7 @@
     "name": "Yellow Nectar",
     "imageurl": "https://img.pokemondb.net/sprites/items/yellow-nectar.png",
     "category": "Hold items",
-    "effect": "A flower nectar obtained at Melemele Meadow. It changes the form of certain species of Pok\u00e9mon."
+    "effect": "A flower nectar obtained at Melemele Meadow. It changes the form of certain species of Pokemon."
   },
   {
     "name": "Yellow Scarf",

--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/ios/Flutter/Flutter.podspec
+++ b/ios/Flutter/Flutter.podspec
@@ -1,18 +1,18 @@
 #
 # NOTE: This podspec is NOT to be published. It is only used as a local source!
+#       This is a generated file; do not edit or check into version control.
 #
 
 Pod::Spec.new do |s|
   s.name             = 'Flutter'
   s.version          = '1.0.0'
   s.summary          = 'High-performance, high-fidelity mobile apps.'
-  s.description      = <<-DESC
-Flutter provides an easy and productive way to build and deploy high-performance mobile apps for Android and iOS.
-                       DESC
   s.homepage         = 'https://flutter.io'
   s.license          = { :type => 'MIT' }
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
-  s.ios.deployment_target = '8.0'
-  s.vendored_frameworks = 'Flutter.framework'
+  s.ios.deployment_target = '9.0'
+  # Framework linking is handled by Flutter tooling, not CocoaPods.
+  # Add a placeholder to satisfy `s.dependency 'Flutter'` plugin podspecs.
+  s.vendored_frameworks = 'path/to/nothing'
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -5,9 +5,9 @@ PODS:
   - FMDB/standard (2.7.5)
   - path_provider (0.0.1):
     - Flutter
-  - sqflite (0.0.1):
+  - sqflite (0.0.2):
     - Flutter
-    - FMDB (~> 2.7.2)
+    - FMDB (>= 2.7.5)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -27,10 +27,10 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sqflite/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
+  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
-  sqflite: 4001a31ff81d210346b500c55b17f4d6c7589dd0
+  sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -231,14 +231,12 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/FMDB/FMDB.framework",
-				"${PODS_ROOT}/../Flutter/Flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/path_provider/path_provider.framework",
 				"${BUILT_PRODUCTS_DIR}/sqflite/sqflite.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FMDB.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/sqflite.framework",
 			);
@@ -356,7 +354,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -435,7 +433,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -482,7 +480,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/lib/data/categories.dart
+++ b/lib/data/categories.dart
@@ -6,7 +6,7 @@ const List<Category> categories = [
   Category(name: 'Pokedex', color: AppColors.teal, route: Routes.pokedex),
   Category(name: 'Moves', color: AppColors.red, route: Routes.pokedex),
   Category(name: 'Abilities', color: AppColors.blue, route: Routes.pokedex),
-  Category(name: 'Items', color: AppColors.yellow, route: Routes.pokedex),
+  Category(name: 'Items', color: AppColors.yellow, route: Routes.itemsList),
   Category(name: 'Locations', color: AppColors.purple, route: Routes.pokedex),
   Category(name: 'Type Effects', color: AppColors.brown, route: Routes.typeEffects),
 ];

--- a/lib/data/repositories/item_repository.dart
+++ b/lib/data/repositories/item_repository.dart
@@ -1,0 +1,34 @@
+import 'package:pokedex/data/source/github/github_datasource.dart';
+import 'package:pokedex/data/source/local/local_datasource.dart';
+import 'package:pokedex/data/source/mappers/github_to_local_mapper.dart';
+import 'package:pokedex/data/source/mappers/local_to_entity_mapper.dart';
+import 'package:pokedex/domain/entities/item.dart';
+
+abstract class ItemRepository {
+  Future<List<Item>> getItems();
+}
+
+class ItemDefaultRepository extends ItemRepository {
+  ItemDefaultRepository({this.githubDataSource, this.localDataSource});
+
+  final GithubDataSource githubDataSource;
+  final LocalDataSource localDataSource;
+
+  @override
+  Future<List<Item>> getItems() async {
+    final hasCachedData = await localDataSource.hasData();
+
+    if (!hasCachedData) {
+      final itemGithubModel = await githubDataSource.getItems();
+      final itemHiveModels = itemGithubModel.map((e) => e.toHiveModel());
+
+      await localDataSource.saveItems(itemHiveModels);
+    }
+
+    final itemHiveModels = await localDataSource.getItems();
+    final itemEntities =
+        itemHiveModels.where((element) => element != null).map((e) => e.toEntity()).toList();
+
+    return itemEntities;
+  }
+}

--- a/lib/data/source/github/github_datasource.dart
+++ b/lib/data/source/github/github_datasource.dart
@@ -9,6 +9,7 @@ class GithubDataSource {
       'https://gist.githubusercontent.com/scitbiz/0bfdd96d3ab9ee20c2e572e47c6834c7/raw/pokemons.json';
   static const String itemsURL =
       'https://gist.githubusercontent.com/scitbiz/69bb2082702ecbdf3d26cd7ba2a2e00d/raw/pokemon_items.json';
+
   GithubDataSource(this.networkManager);
 
   final NetworkManager networkManager;

--- a/lib/data/source/github/github_datasource.dart
+++ b/lib/data/source/github/github_datasource.dart
@@ -1,12 +1,14 @@
 import 'dart:convert';
 
 import 'package:pokedex/core/network.dart';
+import 'package:pokedex/data/source/github/models/item.dart';
 import 'package:pokedex/data/source/github/models/pokemon.dart';
 
 class GithubDataSource {
   static const String url =
       'https://gist.githubusercontent.com/scitbiz/0bfdd96d3ab9ee20c2e572e47c6834c7/raw/pokemons.json';
-
+  static const String itemsURL =
+      'https://gist.github.com/LucasFab/3e1571f3fe2be45fb0daeb6a73c1766f/raw/items.json';
   GithubDataSource(this.networkManager);
 
   final NetworkManager networkManager;
@@ -17,6 +19,15 @@ class GithubDataSource {
     final data = (json.decode(response.data) as List)
         .map((item) => GithubPokemonModel.fromJson(item))
         .toList();
+
+    return data;
+  }
+
+  Future<List<GithubItemModel>> getItems() async {
+    final response = await networkManager.request(RequestMethod.get, itemsURL);
+
+    final data =
+        (json.decode(response.data) as List).map((item) => GithubItemModel.fromJson(item)).toList();
 
     return data;
   }

--- a/lib/data/source/github/github_datasource.dart
+++ b/lib/data/source/github/github_datasource.dart
@@ -8,7 +8,7 @@ class GithubDataSource {
   static const String url =
       'https://gist.githubusercontent.com/scitbiz/0bfdd96d3ab9ee20c2e572e47c6834c7/raw/pokemons.json';
   static const String itemsURL =
-      'https://gist.github.com/LucasFab/3e1571f3fe2be45fb0daeb6a73c1766f/raw/items.json';
+      'https://gist.githubusercontent.com/scitbiz/69bb2082702ecbdf3d26cd7ba2a2e00d/raw/pokemon_items.json';
   GithubDataSource(this.networkManager);
 
   final NetworkManager networkManager;

--- a/lib/data/source/github/models/item.dart
+++ b/lib/data/source/github/models/item.dart
@@ -1,0 +1,29 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'item.g.dart';
+
+@JsonSerializable()
+class GithubItemModel {
+  GithubItemModel(
+    this.name,
+    this.category,
+    this.imageurl,
+    this.effect,
+  );
+
+  factory GithubItemModel.fromJson(Map<String, dynamic> json) => _$GithubItemModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$GithubItemModelToJson(this);
+
+  @JsonKey(disallowNullValue: true)
+  final String name;
+
+  @JsonKey(defaultValue: '')
+  final String category;
+
+  @JsonKey(disallowNullValue: true)
+  final String imageurl;
+
+  @JsonKey(disallowNullValue: true)
+  final String effect;
+}

--- a/lib/data/source/github/models/item.g.dart
+++ b/lib/data/source/github/models/item.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'item.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+GithubItemModel _$GithubItemModelFromJson(Map<String, dynamic> json) {
+  $checkKeys(json, disallowNullValues: const [
+    'name',
+    'category',
+    'imageUrl',
+    'effect',
+  ]);
+  return GithubItemModel(
+    json['name'] as String,
+    json['category'] as String,
+    json['imageurl'] as String,
+    json['effect'] as String,
+  );
+}
+
+Map<String, dynamic> _$GithubItemModelToJson(GithubItemModel instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('name', instance.name);
+  writeNotNull('category', instance.category);
+  writeNotNull('imageurl', instance.imageurl);
+  writeNotNull('effect', instance.effect);
+
+  return val;
+}

--- a/lib/data/source/local/local_datasource.dart
+++ b/lib/data/source/local/local_datasource.dart
@@ -61,6 +61,7 @@ class LocalDataSource {
     final itemBox = Hive.box<ItemHiveModel>(ItemHiveModel.boxKey);
 
     final items = List.generate(itemBox.length, (index) => itemBox.getAt(index));
+
     return items;
   }
 

--- a/lib/data/source/local/local_datasource.dart
+++ b/lib/data/source/local/local_datasource.dart
@@ -25,7 +25,7 @@ class LocalDataSource {
   Future<bool> hasData() async {
     final pokemonBox = Hive.box<PokemonHiveModel>(PokemonHiveModel.boxKey);
     final itemBox = Hive.box<ItemHiveModel>(ItemHiveModel.boxKey);
-    return pokemonBox.length + itemBox.length > 0;
+    return pokemonBox.length > 0 && itemBox.length > 0;
   }
 
   Future<void> savePokemons(Iterable<PokemonHiveModel> pokemons) async {
@@ -61,7 +61,6 @@ class LocalDataSource {
     final itemBox = Hive.box<ItemHiveModel>(ItemHiveModel.boxKey);
 
     final items = List.generate(itemBox.length, (index) => itemBox.getAt(index));
-
     return items;
   }
 

--- a/lib/data/source/local/models/item.dart
+++ b/lib/data/source/local/models/item.dart
@@ -1,0 +1,20 @@
+import 'package:hive/hive.dart';
+
+part 'item.g.dart';
+
+@HiveType(typeId: 4)
+class ItemHiveModel extends HiveObject {
+  static const String boxKey = 'item';
+
+  @HiveField(0)
+  String name;
+
+  @HiveField(1)
+  String category;
+
+  @HiveField(2)
+  String imageurl;
+
+  @HiveField(3)
+  String effect;
+}

--- a/lib/data/source/local/models/item.g.dart
+++ b/lib/data/source/local/models/item.g.dart
@@ -1,0 +1,47 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'item.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class ItemHiveModelAdapter extends TypeAdapter<ItemHiveModel> {
+  @override
+  final int typeId = 4;
+
+  @override
+  ItemHiveModel read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ItemHiveModel()
+      ..name = fields[0] as String
+      ..category = fields[1] as String
+      ..imageurl = fields[2] as String
+      ..effect = fields[3] as String;
+  }
+
+  @override
+  void write(BinaryWriter writer, ItemHiveModel obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.name)
+      ..writeByte(1)
+      ..write(obj.category)
+      ..writeByte(2)
+      ..write(obj.imageurl)
+      ..writeByte(3)
+      ..write(obj.effect);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ItemHiveModelAdapter && runtimeType == other.runtimeType && typeId == other.typeId;
+}

--- a/lib/data/source/mappers/github_to_local_mapper.dart
+++ b/lib/data/source/mappers/github_to_local_mapper.dart
@@ -37,6 +37,6 @@ extension GithubItemModelToLocalX on GithubItemModel {
   ItemHiveModel toHiveModel() => ItemHiveModel()
     ..name = name?.trim() ?? ''
     ..category = category?.trim() ?? ''
-    ..imageurl = name?.trim() ?? ''
-    ..effect = category?.trim() ?? '';
+    ..imageurl = imageurl?.trim() ?? ''
+    ..effect = effect?.trim() ?? '';
 }

--- a/lib/data/source/mappers/github_to_local_mapper.dart
+++ b/lib/data/source/mappers/github_to_local_mapper.dart
@@ -1,5 +1,7 @@
 import 'package:pokedex/core/extensions/string.dart';
+import 'package:pokedex/data/source/github/models/item.dart';
 import 'package:pokedex/data/source/github/models/pokemon.dart';
+import 'package:pokedex/data/source/local/models/item.dart';
 import 'package:pokedex/data/source/local/models/pokemon.dart';
 import 'package:pokedex/data/source/local/models/pokemon_gender.dart';
 import 'package:pokedex/data/source/local/models/pokemon_stats.dart';
@@ -14,11 +16,7 @@ extension GithubPokemonModelToLocalX on GithubPokemonModel {
     ..height = height?.trim() ?? ''
     ..weight = weight?.trim() ?? ''
     ..genera = category?.trim() ?? ''
-    ..eggGroups = eggGroups
-            ?.split(RegExp(r',\s*?'))
-            ?.map((e) => e?.trim() ?? '')
-            ?.toList() ??
-        []
+    ..eggGroups = eggGroups?.split(RegExp(r',\s*?'))?.map((e) => e?.trim() ?? '')?.toList() ?? []
     ..gender = (PokemonGenderHiveModel()
       ..male = genderMalePercentage?.parseDouble() ?? 0.0
       ..female = genderFemalePercentage?.parseDouble() ?? 0.0
@@ -33,4 +31,12 @@ extension GithubPokemonModelToLocalX on GithubPokemonModel {
     ..baseExp = baseExp?.parseDouble()
     ..evolutions = evolutions ?? []
     ..evolutionReason = reason ?? '';
+}
+
+extension GithubItemModelToLocalX on GithubItemModel {
+  ItemHiveModel toHiveModel() => ItemHiveModel()
+    ..name = name?.trim() ?? ''
+    ..category = category?.trim() ?? ''
+    ..imageurl = name?.trim() ?? ''
+    ..effect = category?.trim() ?? '';
 }

--- a/lib/data/source/mappers/local_to_entity_mapper.dart
+++ b/lib/data/source/mappers/local_to_entity_mapper.dart
@@ -46,9 +46,9 @@ extension PokemonStatsHiveModelX on PokemonStatsHiveModel {
 }
 
 extension ItemHiveModelX on ItemHiveModel {
-  Item toEntity({List<ItemHiveModel> evolutions = const []}) => Item(
+  Item toEntity({List<ItemHiveModel> items = const []}) => Item(
         name: name?.trim() ?? '',
-        category: name?.trim() ?? '',
+        category: category?.trim() ?? '',
         image: imageurl?.trim() ?? '',
         effect: effect?.trim() ?? '',
       );

--- a/lib/data/source/mappers/local_to_entity_mapper.dart
+++ b/lib/data/source/mappers/local_to_entity_mapper.dart
@@ -1,6 +1,8 @@
+import 'package:pokedex/data/source/local/models/item.dart';
 import 'package:pokedex/data/source/local/models/pokemon.dart';
 import 'package:pokedex/data/source/local/models/pokemon_gender.dart';
 import 'package:pokedex/data/source/local/models/pokemon_stats.dart';
+import 'package:pokedex/domain/entities/item.dart';
 import 'package:pokedex/domain/entities/pokemon.dart';
 import 'package:pokedex/domain/entities/pokemon_props.dart';
 import 'package:pokedex/domain/entities/pokemon_types.dart';
@@ -40,5 +42,14 @@ extension PokemonStatsHiveModelX on PokemonStatsHiveModel {
         specialDefense: specialDefense ?? 0,
         hp: hp ?? 0,
         speed: speed ?? 0,
+      );
+}
+
+extension ItemHiveModelX on ItemHiveModel {
+  Item toEntity({List<ItemHiveModel> evolutions = const []}) => Item(
+        name: name?.trim() ?? '',
+        category: name?.trim() ?? '',
+        image: imageurl?.trim() ?? '',
+        effect: effect?.trim() ?? '',
       );
 }

--- a/lib/domain/entities/item.dart
+++ b/lib/domain/entities/item.dart
@@ -1,0 +1,13 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+class Item {
+  const Item(
+      {@required this.name, @required this.image, @required this.category, @required this.effect});
+
+  final String name;
+  final String image;
+  final String category;
+  final String effect;
+}

--- a/lib/domain/entities/item.dart
+++ b/lib/domain/entities/item.dart
@@ -3,8 +3,12 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 
 class Item {
-  const Item(
-      {@required this.name, @required this.image, @required this.category, @required this.effect});
+  const Item({
+    @required this.name,
+    @required this.image,
+    @required this.category,
+    @required this.effect,
+  });
 
   final String name;
   final String image;

--- a/lib/domain/usecases/item_usecases.dart
+++ b/lib/domain/usecases/item_usecases.dart
@@ -1,0 +1,14 @@
+import 'package:pokedex/core/usecase.dart';
+import '../../data/repositories/item_repository.dart';
+import '../entities/item.dart';
+
+class GetItemUseCase extends NoParamsUseCase<List<Item>> {
+  const GetItemUseCase(this.repository);
+
+  final ItemRepository repository;
+
+  @override
+  Future<List<Item>> call() {
+    return repository.getItems();
+  }
+}

--- a/lib/providers/providers.dart
+++ b/lib/providers/providers.dart
@@ -1,9 +1,11 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pokedex/core/network.dart';
 import 'package:pokedex/data/repositories/pokemon_repository.dart';
+import 'package:pokedex/data/repositories/item_repository.dart';
 import 'package:pokedex/data/source/github/github_datasource.dart';
 import 'package:pokedex/data/source/local/local_datasource.dart';
 import 'package:pokedex/domain/usecases/pokemon_usecases.dart';
+import 'package:pokedex/domain/usecases/item_usecases.dart';
 import 'package:pokedex/states/states.dart';
 
 part 'data_sources.dart';

--- a/lib/providers/repositories.dart
+++ b/lib/providers/repositories.dart
@@ -9,3 +9,13 @@ final pokemonRepositoryProvider = Provider<PokemonRepository>((ref) {
     localDataSource: localDataSource,
   );
 });
+
+final itemRepositoryProvider = Provider<ItemRepository>((ref) {
+  final githubDataSource = ref.watch(githubSourceProvider);
+  final localDataSource = ref.watch(localSourceProvider);
+
+  return ItemDefaultRepository(
+    githubDataSource: githubDataSource,
+    localDataSource: localDataSource,
+  );
+});

--- a/lib/providers/states.dart
+++ b/lib/providers/states.dart
@@ -11,3 +11,9 @@ final pokemonsStateProvider = ChangeNotifierProvider<PokemonListState>((ref) {
 
   return PokemonListState(getPokemonsUseCase);
 });
+
+final itemStateProvider = ChangeNotifierProvider<ItemListState>((ref) {
+  final getItemUseCase = ref.watch(getItemsUseCaseProvider);
+
+  return ItemListState(getItemUseCase);
+});

--- a/lib/providers/use_cases.dart
+++ b/lib/providers/use_cases.dart
@@ -11,3 +11,9 @@ final getPokemonsUseCaseProvider = Provider<GetPokemonsUseCase>((ref) {
 
   return GetPokemonsUseCase(pokemonRepository);
 });
+
+final getItemsUseCaseProvider = Provider<GetItemUseCase>((ref) {
+  final itemRepository = ref.watch(itemRepositoryProvider);
+
+  return GetItemUseCase(itemRepository);
+});

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,18 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:pokedex/core/fade_page_route.dart';
 import 'package:pokedex/ui/screens/home/home.dart';
+import 'package:pokedex/ui/screens/items_list/items_list.dart';
 import 'package:pokedex/ui/screens/pokedex/pokedex.dart';
 import 'package:pokedex/ui/screens/pokemon_info/pokemon_info.dart';
 import 'package:pokedex/ui/screens/splash/splash.dart';
 import 'package:pokedex/ui/screens/types/type_screen.dart';
 
-enum Routes { splash, home, pokedex, pokemonInfo, typeEffects }
+enum Routes { splash, home, pokedex, pokemonInfo, typeEffects, itemsList }
 
 class _Paths {
   static const String splash = '/';
   static const String home = '/home';
   static const String pokedex = '/home/pokedex';
   static const String pokemonInfo = '/home/pokemon';
+  static const String itemsList = '/home/items';
   static const String typeEffectsScreen = '/home/type';
   static const Map<Routes, String> _pathMap = {
     Routes.splash: _Paths.splash,
@@ -20,6 +22,7 @@ class _Paths {
     Routes.pokedex: _Paths.pokedex,
     Routes.pokemonInfo: _Paths.pokemonInfo,
     Routes.typeEffects: _Paths.typeEffectsScreen,
+    Routes.itemsList: _Paths.itemsList
   };
 
   static String of(Routes route) => _pathMap[route];
@@ -42,6 +45,8 @@ class AppNavigator {
       case _Paths.typeEffectsScreen:
         return FadeRoute(page: TypeEffectScreen());
 
+      case _Paths.itemsList:
+        return FadeRoute(page: ItemsListScreen());
       case _Paths.home:
       default:
         return FadeRoute(page: HomeScreen());

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -47,6 +47,7 @@ class AppNavigator {
 
       case _Paths.itemsList:
         return FadeRoute(page: ItemsListScreen());
+
       case _Paths.home:
       default:
         return FadeRoute(page: HomeScreen());

--- a/lib/states/item_list_state.dart
+++ b/lib/states/item_list_state.dart
@@ -1,0 +1,32 @@
+part of 'states.dart';
+
+class ItemListState with ChangeNotifier {
+  ItemListState(this._getItemsUseCase);
+
+  final GetItemUseCase _getItemsUseCase;
+
+  bool loading = true;
+  bool isError = false;
+  List<Item> items = [];
+
+  void getItems({bool reset = false}) async {
+    if (reset) {
+      items = [];
+    }
+
+    isError = false;
+    loading = true;
+    notifyListeners();
+
+    try {
+      final newItems = await _getItemsUseCase();
+      items = [...items, ...newItems];
+    } catch (e) {
+      isError = true;
+    }
+
+    loading = false;
+
+    notifyListeners();
+  }
+}

--- a/lib/states/states.dart
+++ b/lib/states/states.dart
@@ -2,5 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:pokedex/domain/entities/pokemon.dart';
 import 'package:pokedex/domain/usecases/pokemon_usecases.dart';
 
+import 'package:pokedex/domain/entities/item.dart';
+import 'package:pokedex/domain/usecases/item_usecases.dart';
+
 part 'current_pokemon_state.dart';
 part 'pokemon_list_state.dart';
+part 'item_list_state.dart';

--- a/lib/ui/screens/items_list/items_list.dart
+++ b/lib/ui/screens/items_list/items_list.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:pokedex/configs/durations.dart';
+import 'package:pokedex/ui/screens/items_list/widgets/items_grid.dart';
+import 'package:pokedex/ui/widgets/pokeball_background.dart';
+
+class ItemsListScreen extends StatefulWidget {
+  const ItemsListScreen();
+
+  @override
+  _ItemsListScreenState createState() => _ItemsListScreenState();
+}
+
+class _ItemsListScreenState extends State<ItemsListScreen> with SingleTickerProviderStateMixin {
+  Animation<double> _fabAnimation;
+  AnimationController _fabController;
+  bool _isFabMenuVisible = false;
+
+  @override
+  void initState() {
+    _fabController = AnimationController(
+      vsync: this,
+      duration: animationDuration,
+    );
+
+    /*_fabAnimation = _fabController.curvedTweenAnimation(
+      begin: 0.0,
+      end: 1.0,
+    );*/
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _fabController?.dispose();
+
+    super.dispose();
+  }
+
+  void _toggleFabMenu() {
+    _isFabMenuVisible = !_isFabMenuVisible;
+
+    if (_isFabMenuVisible) {
+      _fabController.forward();
+    } else {
+      _fabController.reverse();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PokeballBackground(
+      child: Stack(
+        children: [
+          ItemsGrid()
+          /*_FabOverlayBackground(
+            animation: _fabAnimation,
+            onPressOut: _toggleFabMenu,
+          ),*/
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/items_list/items_list.dart
+++ b/lib/ui/screens/items_list/items_list.dart
@@ -22,11 +22,6 @@ class _ItemsListScreenState extends State<ItemsListScreen> with SingleTickerProv
       duration: animationDuration,
     );
 
-    /*_fabAnimation = _fabController.curvedTweenAnimation(
-      begin: 0.0,
-      end: 1.0,
-    );*/
-
     super.initState();
   }
 

--- a/lib/ui/screens/items_list/widgets/item_card.dart
+++ b/lib/ui/screens/items_list/widgets/item_card.dart
@@ -1,0 +1,175 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:pokedex/configs/colors.dart';
+import 'package:pokedex/configs/images.dart';
+import 'package:pokedex/domain/entities/item.dart';
+import 'package:pokedex/domain/entities/pokemon.dart';
+import 'package:pokedex/ui/screens/items_list/widgets/item_category.dart';
+import 'package:pokedex/ui/widgets/pokemon_type.dart';
+import 'package:pokedex/core/extensions/context.dart';
+import 'package:pokedex/ui/widgets/spacer.dart';
+
+class ItemCard extends StatelessWidget {
+  static const double _pokeballFraction = 0.60;
+  static const double _itemFraction = 0.61;
+
+  const ItemCard(
+    this.item, {
+    this.onPress,
+    @required this.index,
+  });
+
+  final int index;
+  final Function onPress;
+  final Item item;
+
+  Widget _buildPokeballDecoration({@required double height}) {
+    final pokeballSize = height * _pokeballFraction;
+
+    return Positioned(
+      bottom: -height * 0.13,
+      right: -height * 0.03,
+      child: Image(
+        image: AppImages.pokeball,
+        width: pokeballSize,
+        height: pokeballSize,
+        color: Colors.white.withOpacity(0.14),
+      ),
+    );
+  }
+
+  Widget _buildItem({@required double height}) {
+    final itemSize = height * _itemFraction;
+
+    return Positioned(
+      bottom: -2,
+      right: 2,
+      child: Hero(
+        tag: item.image,
+        child: CachedNetworkImage(
+          imageUrl: item.image,
+          width: itemSize,
+          height: itemSize,
+          imageRenderMethodForWeb: ImageRenderMethodForWeb.HtmlImage,
+          useOldImageOnUrlChange: true,
+          fit: BoxFit.contain,
+          alignment: Alignment.bottomRight,
+          placeholder: (context, url) => Image(
+            image: AppImages.bulbasaur,
+            width: itemSize,
+            height: itemSize,
+            color: Colors.black12,
+          ),
+          errorWidget: (_, __, error) => Stack(
+            alignment: Alignment.center,
+            children: [
+              Image(
+                image: AppImages.bulbasaur,
+                width: itemSize,
+                height: itemSize,
+                color: Colors.black12,
+              ),
+              Icon(
+                Icons.warning_amber_rounded,
+                size: itemSize * 0.4,
+                color: Colors.black45,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constrains) {
+        final itemHeight = constrains.maxHeight;
+
+        return Container(
+          decoration: BoxDecoration(
+            color: AppColors.grey,
+            borderRadius: BorderRadius.circular(15),
+            boxShadow: [
+              BoxShadow(
+                color: AppColors.grey.withOpacity(0.12),
+                blurRadius: 30,
+                offset: Offset(0, 8),
+              ),
+            ],
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(15),
+            child: Material(
+              color: AppColors.grey,
+              child: InkWell(
+                onTap: onPress,
+                splashColor: Colors.white10,
+                highlightColor: Colors.white10,
+                child: Stack(
+                  children: [
+                    _buildPokeballDecoration(height: itemHeight),
+                    _buildItem(height: itemHeight),
+                    _CardContent(item),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _CardContent extends StatelessWidget {
+  const _CardContent(this.item, {Key key}) : super(key: key);
+
+  final Item item;
+
+  Widget _buildCategory(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: context.responsive(3),
+        right: context.responsive(3),
+      ),
+      child: ItemCategory(item.category),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: 16,
+          right: 16,
+          top: context.responsive(24),
+          bottom: context.responsive(16),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.max,
+          children: <Widget>[
+            Hero(
+              tag: item.name,
+              child: Text(
+                item.name,
+                style: TextStyle(
+                  fontSize: 14,
+                  height: 0.7,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+            VSpacer(context.responsive(10)),
+            _buildCategory(context),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/items_list/widgets/item_category.dart
+++ b/lib/ui/screens/items_list/widgets/item_category.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:pokedex/core/extensions/context.dart';
+import 'package:pokedex/ui/widgets/spacer.dart';
+
+class ItemCategory extends StatelessWidget {
+  const ItemCategory(
+    this.name, {
+    Key key,
+  }) : super(key: key);
+
+  final String name;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(top: 3),
+      child: Material(
+        color: Colors.transparent,
+        child: Container(
+          padding: EdgeInsets.symmetric(
+            horizontal: 12,
+            vertical: context.responsive(4),
+          ),
+          decoration: ShapeDecoration(
+            shape: StadiumBorder(),
+            color: Colors.white.withOpacity(0.2),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(
+                name,
+                textScaleFactor: 1,
+                style: TextStyle(
+                  fontSize: 10,
+                  height: 0.8,
+                  fontWeight: FontWeight.normal,
+                  color: Colors.white,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              HSpacer(5),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/items_list/widgets/items_grid.dart
+++ b/lib/ui/screens/items_list/widgets/items_grid.dart
@@ -7,6 +7,7 @@ import 'package:pokedex/data/repositories/item_repository.dart';
 import 'package:pokedex/domain/entities/item.dart';
 import 'package:pokedex/domain/entities/pokemon.dart';
 import 'package:pokedex/providers/providers.dart';
+import 'package:pokedex/ui/screens/items_list/widgets/item_card.dart';
 import 'package:pokedex/ui/screens/pokedex/widgets/pokemon_card.dart';
 import 'package:pokedex/ui/widgets/main_app_bar.dart';
 import 'package:pokedex/ui/widgets/pokemon_refresh_control.dart';
@@ -62,7 +63,7 @@ class _ItemsGridState extends State<ItemsGrid> {
 
   List<Widget> _buildHeader(BuildContext context, bool innerBoxIsScrolled) {
     return [
-      MainSliverAppBar(),
+      MainSliverAppBar(title: "Items"),
     ];
   }
 
@@ -77,12 +78,9 @@ class _ItemsGridState extends State<ItemsGrid> {
           mainAxisSpacing: 10,
         ),
         delegate: SliverChildBuilderDelegate(
-          (context, index) => Text(items[index].name),
-          /*PokemonCard(
-            pokemons[index],
-            index: index,
-            onPress: () => _onPokemonPress(index, pokemons[index]),
-          ),*/
+          (context, index) => ItemCard(items[index], index: index),
+          //Text(items[index].name),
+
           childCount: items.length,
         ),
       ),

--- a/lib/ui/screens/items_list/widgets/items_grid.dart
+++ b/lib/ui/screens/items_list/widgets/items_grid.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pokedex/configs/images.dart';
+import 'package:pokedex/data/repositories/item_repository.dart';
+import 'package:pokedex/domain/entities/item.dart';
+import 'package:pokedex/domain/entities/pokemon.dart';
+import 'package:pokedex/providers/providers.dart';
+import 'package:pokedex/ui/screens/pokedex/widgets/pokemon_card.dart';
+import 'package:pokedex/ui/widgets/main_app_bar.dart';
+import 'package:pokedex/ui/widgets/pokemon_refresh_control.dart';
+import 'package:pokedex/routes.dart';
+
+class ItemsGrid extends StatefulWidget {
+  @override
+  _ItemsGridState createState() => _ItemsGridState();
+}
+
+class _ItemsGridState extends State<ItemsGrid> {
+  static const double _endReachedThreshold = 200;
+
+  final GlobalKey<NestedScrollViewState> _scrollKey = GlobalKey();
+  ScrollController get innerController => _scrollKey.currentState?.innerController;
+
+  @override
+  void initState() {
+    super.initState();
+    scheduleMicrotask(() {
+      context.read(itemStateProvider).getItems(reset: true);
+      innerController?.addListener(_onScroll);
+    });
+  }
+
+  @override
+  void dispose() {
+    innerController?.dispose();
+
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (innerController != null && !innerController.hasClients) return;
+
+    final thresholdReached = innerController.position.extentAfter < _endReachedThreshold;
+
+    if (thresholdReached) {
+      // Load more!
+      context.read(itemStateProvider).getItems();
+    }
+  }
+
+  Future _onRefresh() async {
+    context.read(itemStateProvider).getItems(reset: true);
+  }
+
+  void onItemPress(int index, Pokemon pokemon) {
+    context.read(currentPokemonStateProvider).setPokemon(index, pokemon);
+
+    AppNavigator.push(Routes.pokemonInfo, pokemon);
+  }
+
+  List<Widget> _buildHeader(BuildContext context, bool innerBoxIsScrolled) {
+    return [
+      MainSliverAppBar(),
+    ];
+  }
+
+  Widget _buildGrid({List<Item> items = const []}) {
+    return SliverPadding(
+      padding: EdgeInsets.all(28),
+      sliver: SliverGrid(
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          childAspectRatio: 1.4,
+          crossAxisSpacing: 10,
+          mainAxisSpacing: 10,
+        ),
+        delegate: SliverChildBuilderDelegate(
+          (context, index) => Text(items[index].name),
+          /*PokemonCard(
+            pokemons[index],
+            index: index,
+            onPress: () => _onPokemonPress(index, pokemons[index]),
+          ),*/
+          childCount: items.length,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLoadMoreIndicator() {
+    return SliverToBoxAdapter(
+      child: Container(
+        padding: EdgeInsets.only(bottom: 28),
+        alignment: Alignment.center,
+        child: Image(image: AppImages.pikloader),
+      ),
+    );
+  }
+
+  Widget _buildError() {
+    return SliverFillRemaining(
+      child: Container(
+        padding: EdgeInsets.only(bottom: 28),
+        alignment: Alignment.center,
+        child: Icon(
+          Icons.warning_amber_rounded,
+          size: 60,
+          color: Colors.black26,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NestedScrollView(
+      key: _scrollKey,
+      headerSliverBuilder: _buildHeader,
+      body: Consumer(builder: (_, watch, __) {
+        final itemState = watch(itemStateProvider);
+
+        return CustomScrollView(
+          slivers: [
+            PokemonRefreshControl(onRefresh: _onRefresh),
+            if (itemState.isError)
+              _buildError()
+            else ...[
+              _buildGrid(items: itemState.items),
+            ]
+          ],
+        );
+      }),
+    );
+  }
+}

--- a/lib/ui/screens/items_list/widgets/items_grid.dart
+++ b/lib/ui/screens/items_list/widgets/items_grid.dart
@@ -29,7 +29,6 @@ class _ItemsGridState extends State<ItemsGrid> {
     super.initState();
     scheduleMicrotask(() {
       context.read(itemStateProvider).getItems(reset: true);
-      innerController?.addListener(_onScroll);
     });
   }
 
@@ -38,17 +37,6 @@ class _ItemsGridState extends State<ItemsGrid> {
     innerController?.dispose();
 
     super.dispose();
-  }
-
-  void _onScroll() {
-    if (innerController != null && !innerController.hasClients) return;
-
-    final thresholdReached = innerController.position.extentAfter < _endReachedThreshold;
-
-    if (thresholdReached) {
-      // Load more!
-      context.read(itemStateProvider).getItems();
-    }
   }
 
   Future _onRefresh() async {
@@ -79,8 +67,6 @@ class _ItemsGridState extends State<ItemsGrid> {
         ),
         delegate: SliverChildBuilderDelegate(
           (context, index) => ItemCard(items[index], index: index),
-          //Text(items[index].name),
-
           childCount: items.length,
         ),
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,21 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "12.0.0"
+    version: "14.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.40.6"
+    version: "0.41.2"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.13"
   args:
     dependency: transitive
     description:
@@ -28,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -42,63 +49,63 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.6.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.6"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.10"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.3"
+    version: "1.5.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.6"
+    version: "1.11.5"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.3"
+    version: "6.1.10"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.2"
+    version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.1.0"
+    version: "8.1.3"
   cached_network_image:
     dependency: "direct main"
     description:
       name: cached_network_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.3"
+    version: "2.5.1"
   characters:
     dependency: transitive
     description:
@@ -112,21 +119,21 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.5"
   clock:
     dependency: transitive
     description:
@@ -140,7 +147,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.0"
+    version: "3.7.0"
   collection:
     dependency: transitive
     description:
@@ -161,14 +168,14 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.10"
+    version: "1.3.12"
   dartx:
     dependency: transitive
     description:
@@ -197,20 +204,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.2"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.1"
+    version: "6.1.2"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.11"
+    version: "1.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -229,14 +243,14 @@ packages:
       name: flutter_cache_manager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "2.1.2"
   flutter_riverpod:
     dependency: "direct main"
     description:
       name: flutter_riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1"
+    version: "0.12.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -248,14 +262,14 @@ packages:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.0"
+    version: "0.12.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.2"
   graphs:
     dependency: transitive
     description:
@@ -305,6 +319,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
+  image:
+    dependency: transitive
+    description:
+      name: image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.19"
   intl:
     dependency: "direct main"
     description:
@@ -318,14 +339,14 @@ packages:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "0.3.5"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.3"
   json_annotation:
     dependency: "direct main"
     description:
@@ -339,14 +360,14 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "3.5.1"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.4"
+    version: "1.0.2"
   matcher:
     dependency: transitive
     description:
@@ -360,28 +381,14 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6+3"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
+    version: "1.0.1"
   octo_image:
     dependency: transitive
     description:
@@ -409,7 +416,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.11"
+    version: "1.6.28"
   path_provider_linux:
     dependency: transitive
     description:
@@ -423,98 +430,112 @@ packages:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+3"
+    version: "0.0.4+8"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.5"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.2"
+    version: "1.11.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0"
   platform:
     dependency: transitive
     description:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.0.2"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   process:
     dependency: transitive
     description:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.13"
+    version: "4.2.4"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "2.1.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.8"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.5"
   riverpod:
     dependency: transitive
     description:
       name: riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1"
+    version: "0.12.4"
   rxdart:
     dependency: transitive
     description:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.24.1"
+    version: "0.25.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "0.2.4+1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -533,7 +554,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.8"
+    version: "0.9.10+3"
   source_span:
     dependency: transitive
     description:
@@ -547,14 +568,14 @@ packages:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2+4"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2+1"
+    version: "1.0.3+3"
   stack_trace:
     dependency: transitive
     description:
@@ -568,7 +589,7 @@ packages:
       name: state_notifier
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0"
+    version: "0.7.1"
   stream_channel:
     dependency: transitive
     description:
@@ -582,7 +603,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
@@ -610,21 +631,21 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   time:
     dependency: transitive
     description:
       name: time
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   timing:
     dependency: transitive
     description:
       name: timing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1+2"
+    version: "0.1.1+3"
   typed_data:
     dependency: transitive
     description:
@@ -638,7 +659,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.2"
   vector_math:
     dependency: transitive
     description:
@@ -652,28 +673,42 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+15"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.1"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.2"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.5.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  dart: ">=2.14.0 <3.0.0"
+  flutter: ">=1.22.2"


### PR DESCRIPTION
Hello,

This Pull Request is based on the add of the Items List to the Pokedex.

I created the repository, providers, use_cases to manage the data. I had to create my own gist to manage the data of the items, if you want to create it yourself tell me and give me the URL and I will change the URL in the repository.

For the front-end part I chose to stay with something quite similar to the list of the pokemon in the pokedex, meaning that you have a list of the items with an image and the name of the item (and the category of it).

Unfortunately, some items on the json data had a correct URL but there was only one white pixel on this URL for the image so some items don't have an image.

Feel free to comment any suggestions to make it better !