### PR TITLE
FIX: issue #83

### DIFF
--- a/lib/presenter/widgets/pokemon_card.dart
+++ b/lib/presenter/widgets/pokemon_card.dart
@@ -97,7 +97,7 @@ class PokemonCard extends StatelessWidget {
         style: const TextStyle(
           fontSize: 14,
           fontWeight: FontWeight.bold,
-          color: Colors.black12,
+          color: Colors.white70,
         ),
       ),
     );


### PR DESCRIPTION
FIX: Issue #83 
Here , I have fixed the issue 

Steps to check :

1. Launch the app 
2. Go for pokedex
3. Review the numbers over it .

Initially it was this : 
![image](https://github.com/user-attachments/assets/1df5c3e0-5e62-4e14-871f-108d344d36ea)

Now , it is like this : 
![Screenshot_20241213-204440](https://github.com/user-attachments/assets/d832fe4d-97d9-4528-b2cd-2819039232eb)

Let me know if it is good or not 
