### PR TITLE
FIX: Issue of showing static data #85

### DIFF
--- a/lib/presenter/pages/home/home.dart
+++ b/lib/presenter/pages/home/home.dart
@@ -1,5 +1,5 @@
+import 'dart:convert';
 import 'dart:math';
-
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -16,6 +16,8 @@ import 'package:pokedex/presenter/widgets/button.dart';
 import 'package:pokedex/presenter/widgets/input.dart';
 import 'package:pokedex/presenter/widgets/keyboard.dart';
 import 'package:pokedex/presenter/widgets/scaffold.dart';
+import 'package:http/http.dart' as http;
+import 'package:url_launcher/url_launcher.dart';
 
 part 'widgets/category_card.dart';
 part 'widgets/news_card.dart';

--- a/lib/presenter/pages/home/sections/news.dart
+++ b/lib/presenter/pages/home/sections/news.dart
@@ -3,40 +3,96 @@ part of '../home.dart';
 class _NewsSection extends StatelessWidget {
   const _NewsSection();
 
+  Future<List<List<String>>> _fetchPokemonNews() async {
+    final List<List<String>> _articles = [];
+    final url = Uri.parse(
+        'https://newsapi.org/v2/everything?q=pokemon&sortBy=publishedAt&language=en&apiKey={YOUR API KEY}');
+
+    try {
+      final response = await http.get(url);
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        final articles = data['articles'];
+        for (var article in articles) {
+          final title = article['title'];
+          final date = article['publishedAt'];
+          final url = article['url'];
+          if (title != null &&
+              (title.contains('Pokemon') || title.contains('Pokémon '))) {
+            _articles.add([title, formatDate(date), url]);
+          }
+        }
+      } else {
+        print('Failed to load data: ${response.statusCode}');
+      }
+    } catch (e) {
+      print('Error occurred: $e');
+    }
+    return _articles;
+  }
+
+  String formatDate(String? date) {
+    if (date == null) return 'Unknown Date';
+
+    // Parse the date string to a DateTime object
+    DateTime parsedDate = DateTime.parse(date);
+
+    // Format the date manually (e.g., "2024-12-11 06:37:41")
+    return '${parsedDate.year}-${parsedDate.month.toString().padLeft(2, '0')}-${parsedDate.day.toString().padLeft(2, '0')} ${parsedDate.hour.toString().padLeft(2, '0')}:${parsedDate.minute.toString().padLeft(2, '0')}';
+  }
+
   @override
   Widget build(BuildContext context) {
-    return ListView(
-      physics: const ClampingScrollPhysics(),
-      padding: const EdgeInsets.all(24),
-      children: <Widget>[
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(
-              'Pokémon News',
-              style: context.typographies.headingSmall,
+    return FutureBuilder<List<List<String>>>(
+      future: _fetchPokemonNews(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          return Center(
+              child: Text('Check your internet connection: ${snapshot.error}'));
+        }
+
+        return ListView(
+          physics: const ClampingScrollPhysics(),
+          padding: const EdgeInsets.all(24),
+          children: <Widget>[
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Pokémon News',
+                  style: context.typographies.headingSmall,
+                ),
+                TextButton(
+                  onPressed: () {},
+                  style: TextButton.styleFrom(
+                      foregroundColor: context.colors.secondary),
+                  child: const Text('View All'),
+                ),
+              ],
             ),
-            TextButton(
-              onPressed: () {},
-              style: TextButton.styleFrom(foregroundColor: context.colors.secondary),
-              child: const Text('View All'),
+            ListView.separated(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: 9,
+              separatorBuilder: (_, __) => const Divider(height: 24),
+              itemBuilder: (_, index) {
+                final _articles = snapshot.data ?? [];
+                return _NewsListTile(
+                  title: _articles[index][0],
+                  time: _articles[index][1],
+                  url: _articles[index][2],
+                  thumbnail: const AssetImage('assets/images/thumbnail.png'),
+                );
+              },
             ),
           ],
-        ),
-        ListView.separated(
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          itemCount: 9,
-          separatorBuilder: (_, __) => const Divider(height: 24),
-          itemBuilder: (_, __) {
-            return const _NewsListTile(
-              title: 'Pokémon Rumble Rush Arrives Soon',
-              time: '15 May 2019',
-              thumbnail: AssetImage('assets/images/thumbnail.png'),
-            );
-          },
-        ),
-      ],
+        );
+      },
     );
   }
 }

--- a/lib/presenter/pages/home/widgets/news_card.dart
+++ b/lib/presenter/pages/home/widgets/news_card.dart
@@ -4,45 +4,56 @@ class _NewsListTile extends StatelessWidget {
   final ImageProvider thumbnail;
   final String title;
   final String time;
+  final String url;
 
   const _NewsListTile({
     required this.title,
     required this.time,
     required this.thumbnail,
+    required this.url,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisSize: MainAxisSize.max,
-      children: <Widget>[
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text(
-                title,
-                style: context.typographies.body.withWeight(FontWeight.bold),
-              ),
-              const SizedBox(height: 6),
-              Text(
-                time,
-                style: context.typographies.caption.withColor(context.colors.hint),
-              ),
-            ],
+    return GestureDetector(
+      onTap: () async {
+        if (!await launchUrl(Uri.parse(url),
+            mode: LaunchMode.externalApplication)) {
+          throw Exception('Could not launch $url');
+        }
+      },
+      child: Row(
+        mainAxisSize: MainAxisSize.max,
+        children: <Widget>[
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  title,
+                  style: context.typographies.body.withWeight(FontWeight.bold),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  time,
+                  style: context.typographies.caption
+                      .withColor(context.colors.hint),
+                ),
+              ],
+            ),
           ),
-        ),
-        const SizedBox(width: 36),
-        ClipRRect(
-          borderRadius: BorderRadius.circular(12),
-          child: Image(
-            image: thumbnail,
-            width: 110,
-            height: 66,
-            fit: BoxFit.cover,
+          const SizedBox(width: 36),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: Image(
+              image: thumbnail,
+              width: 110,
+              height: 66,
+              fit: BoxFit.cover,
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/presenter/widgets/pokemon_card.dart
+++ b/lib/presenter/widgets/pokemon_card.dart
@@ -97,7 +97,7 @@ class PokemonCard extends StatelessWidget {
         style: const TextStyle(
           fontSize: 14,
           fontWeight: FontWeight.bold,
-          color: Colors.black12,
+          color: Colors.white70,
         ),
       ),
     );


### PR DESCRIPTION
Description : #85 
The Pokémon app's news section is currently displaying only static data, meaning it does not update dynamically with new news or events as expected. This issue limits the app's ability to provide the latest Pokémon-related updates to users, reducing the overall user experience.
Changes Made: 
- Implemented API integration to fetch real-time Pokémon news.
- Updated the data-fetching logic to ensure proper parsing and display of dynamic content in the news section.
- Added error handling to gracefully manage scenarios where the API fails to respond or returns invalid data.
- Tested the implementation to verify smooth functionality and ensure no regressions.
- Also added the tap action , so that if you tap on any news tile , you will be redirected to the news in your default browser .

To test : 

1. Head on to [News API](https://newsapi.org/)
2. Create your free api key from it 
3. Paste your API key in news.dart 
4. And all set .
5. Launch the app .
6. Head on to news section of it .
7.  Tap on any news tile to know more about that . 

Screenshots for the reference: 

Initially it was like this :
![image](https://github.com/user-attachments/assets/39cee0c2-9b60-4b9a-afd5-6913510af1b9)

Now it is : 

![Screenshot_20241213-204456](https://github.com/user-attachments/assets/fbd22c50-cf7b-49ea-aa65-15926dd2979c)



